### PR TITLE
Re-seed processed_graph_hashes from MySQL on Redis recovery to prevent cycles

### DIFF
--- a/src/main/java/com/setminusx/ramsey/qm/client/MiddlewareClient.java
+++ b/src/main/java/com/setminusx/ramsey/qm/client/MiddlewareClient.java
@@ -78,6 +78,20 @@ public class MiddlewareClient {
 
     }
 
+    public List<Stage> getRecentStagesByCampaignIdAndStatus(Integer campaignId, Stage.Status status, int count) {
+
+        String getStageUri = UriComponentsBuilder.fromUriString(stageUrl)
+                .queryParam("campaignId", campaignId)
+                .queryParam("status", status)
+                .queryParam("count", count)
+                .toUriString();
+
+        return Optional.ofNullable(restTemplate.getForObject(getStageUri, Stage[].class))
+                .map(Arrays::asList)
+                .orElse(Collections.emptyList());
+
+    }
+
     public void updateStage(Stage stage) {
         restTemplate.put(stageUrl + "/" + stage.getStageId(), stage);
     }

--- a/src/main/java/com/setminusx/ramsey/qm/config/RamseyConfig.java
+++ b/src/main/java/com/setminusx/ramsey/qm/config/RamseyConfig.java
@@ -95,6 +95,13 @@ public class RamseyConfig {
          * Allows in-flight work to complete. Default: 60000 (60 seconds)
          */
         private Long exhaustionDelayMs = 60000L;
+
+        /**
+         * Number of recent stages to re-seed into processed_graph_hashes on Redis recovery.
+         * Higher values give stronger cycle protection at the cost of more DB fetches on restart.
+         * Default: 50
+         */
+        private Integer cyclePreventionGraphLookbackCount = 50;
     }
 
 }

--- a/src/main/java/com/setminusx/ramsey/qm/controller/StageProgressionMonitor.java
+++ b/src/main/java/com/setminusx/ramsey/qm/controller/StageProgressionMonitor.java
@@ -266,6 +266,36 @@ public class StageProgressionMonitor {
         }
 
         initializeRedisForStage(stage, graph);
+
+        // Re-seed processed graph hashes if they were also lost (prevents cycles after Redis wipe)
+        if (redisQueueService.isProcessedGraphHashesEmpty()) {
+            reseedProcessedGraphHashes(stage.getCampaignId());
+        }
+    }
+
+    /**
+     * Re-seeds the processed_graph_hashes set from MySQL after Redis data loss.
+     * Fetches the most recent INACTIVE stages (up to top-results-count) and adds
+     * their base graph hashes, preventing the system from revisiting already-exhausted graphs.
+     */
+    private void reseedProcessedGraphHashes(Integer campaignId) {
+        int count = ramseyConfig.getStage().getCyclePreventionGraphLookbackCount();
+        log.info("Re-seeding processed_graph_hashes from last {} INACTIVE stages for campaign {}...", count, campaignId);
+
+        List<Stage> recentStages = middlewareClient.getRecentStagesByCampaignIdAndStatus(
+                campaignId, Stage.Status.INACTIVE, count);
+
+        int seeded = 0;
+        for (Stage stage : recentStages) {
+            Graph graph = middlewareClient.getGraphById(stage.getBaseGraphId());
+            if (graph != null && graph.getEdgeData() != null) {
+                String hash = GraphHashUtil.computeHash(graph.getEdgeData());
+                redisQueueService.addProcessedGraphHash(hash);
+                seeded++;
+            }
+        }
+
+        log.info("Re-seeded {} processed graph hashes from recent stage history", seeded);
     }
 
     private void initializeRedisForStage(Stage stage, Graph graph) {

--- a/src/main/java/com/setminusx/ramsey/qm/controller/StageProgressionMonitor.java
+++ b/src/main/java/com/setminusx/ramsey/qm/controller/StageProgressionMonitor.java
@@ -247,6 +247,12 @@ public class StageProgressionMonitor {
         if (stage.getWorkEnumerationStrategy() != null) {
             checkAndInitializeStage(stage);
         }
+
+        // Re-seed processed graph hashes independently — handles the case where only
+        // that key was lost while stage_config remained intact
+        if (redisQueueService.isProcessedGraphHashesEmpty()) {
+            reseedProcessedGraphHashes(stage.getCampaignId());
+        }
     }
 
     private void checkAndInitializeStage(Stage stage) {
@@ -266,11 +272,6 @@ public class StageProgressionMonitor {
         }
 
         initializeRedisForStage(stage, graph);
-
-        // Re-seed processed graph hashes if they were also lost (prevents cycles after Redis wipe)
-        if (redisQueueService.isProcessedGraphHashesEmpty()) {
-            reseedProcessedGraphHashes(stage.getCampaignId());
-        }
     }
 
     /**

--- a/src/main/java/com/setminusx/ramsey/qm/service/RedisQueueService.java
+++ b/src/main/java/com/setminusx/ramsey/qm/service/RedisQueueService.java
@@ -313,4 +313,12 @@ public class RedisQueueService {
         return members != null ? members : Set.of();
     }
 
+    /**
+     * Check if the processed graph hashes set is empty (e.g., after Redis data loss).
+     */
+    public boolean isProcessedGraphHashesEmpty() {
+        Long size = redisTemplate.opsForSet().size(PROCESSED_GRAPH_HASHES_KEY);
+        return size == null || size == 0;
+    }
+
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,3 +15,4 @@ ramsey:
   stage:
     top-results-count: ${TOP_RESULTS_COUNT:10}
     exhaustion-delay-ms: ${EXHAUSTION_DELAY_MS:60000}
+    cycle-prevention-graph-lookback-count: ${CYCLE_PREVENTION_GRAPH_LOOKBACK_COUNT:50}


### PR DESCRIPTION
## Summary
- On Redis data loss, `ensureActiveStageInitialized` now also re-seeds `processed_graph_hashes` from the most recent INACTIVE stages, preventing the system from revisiting already-exhausted graphs
- Adds `cyclePreventionGraphLookbackCount` config property (default 50), bound to `CYCLE_PREVENTION_GRAPH_LOOKBACK_COUNT` env var
- Adds `isProcessedGraphHashesEmpty()` to `RedisQueueService`
- Adds `getRecentStagesByCampaignIdAndStatus(count)` to `MiddlewareClient`
- Adds `reseedProcessedGraphHashes` to `StageProgressionMonitor`, called automatically when stage config is re-initialized and hash set is empty

## Context
Previously a Redis wipe would restore the stage counter within 5 seconds (via `ensureActiveStageInitialized`) but permanently blind cycle prevention — the system could loop through previously exhausted graphs indefinitely. Requires companion PR benfff85/ramsey-mw#feature/cycle-prevention-reinit for the new stages endpoint.

## Test plan
- [ ] After a Redis flush, `ensureActiveStageInitialized` logs re-initialization and re-seeding of graph hashes
- [ ] `processed_graph_hashes` contains hashes for the last 50 INACTIVE stages after recovery
- [ ] System does not revisit previously processed graphs after Redis recovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)