### PR TITLE
Stage totalWorkUnits for DUAL_EDGE_CARDINALITY_WITH_SINGLES

### DIFF
--- a/src/main/java/com/setminusx/ramsey/qm/controller/StageProgressionMonitor.java
+++ b/src/main/java/com/setminusx/ramsey/qm/controller/StageProgressionMonitor.java
@@ -238,6 +238,22 @@ public class StageProgressionMonitor {
     }
 
     /**
+     * Total work units for a stage. Pair strategies use redCount * blueCount.
+     * DUAL_EDGE_CARDINALITY_WITH_SINGLES prepends one work unit per
+     * majority-color edge (both colors when tied) — this MUST match the Rust
+     * worker's DualCardinalityWithSinglesEnumerator; the worker refuses the
+     * stage if the totals disagree.
+     */
+    static long computeTotalWorkUnits(long redCount, long blueCount, String strategy) {
+        long pairs = redCount * blueCount;
+        if ("DUAL_EDGE_CARDINALITY_WITH_SINGLES".equals(strategy)) {
+            long singles = (redCount == blueCount) ? redCount + blueCount : Math.max(redCount, blueCount);
+            return singles + pairs;
+        }
+        return pairs;
+    }
+
+    /**
      * Format edges for URL parameter: {{v1:v2},{v3:v4}}
      */
     private String formatEdgesForUrl(List<Edge> edges) {
@@ -331,7 +347,7 @@ public class StageProgressionMonitor {
                 blueCount++;
             }
         }
-        long calculatedTotalPairs = redCount * blueCount;
+        long calculatedTotalPairs = computeTotalWorkUnits(redCount, blueCount, stage.getWorkEnumerationStrategy());
 
         log.info("Initializing counter-based mode for stage {}: redEdges={}, blueEdges={}, totalPairs={}, strategy={}",
                 stage.getStageId(), redCount, blueCount, calculatedTotalPairs, stage.getWorkEnumerationStrategy());

--- a/src/test/java/com/setminusx/ramsey/qm/controller/StageProgressionMonitorTest.java
+++ b/src/test/java/com/setminusx/ramsey/qm/controller/StageProgressionMonitorTest.java
@@ -1,0 +1,37 @@
+package com.setminusx.ramsey.qm.controller;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class StageProgressionMonitorTest {
+
+    @Test
+    void pairStrategiesCountRedTimesBlue() {
+        assertEquals(19810L * 19811L,
+                StageProgressionMonitor.computeTotalWorkUnits(19810, 19811, "DUAL_EDGE_CARDINALITY"));
+        assertEquals(19810L * 19811L,
+                StageProgressionMonitor.computeTotalWorkUnits(19810, 19811, "BASIC"));
+    }
+
+    @Test
+    void singlesStrategyAddsMajorityColorCount() {
+        // Stage 8319 shape: 19,810 red / 19,811 blue -> majority blue.
+        assertEquals(19811L + 19810L * 19811L,
+                StageProgressionMonitor.computeTotalWorkUnits(19810, 19811, "DUAL_EDGE_CARDINALITY_WITH_SINGLES"));
+        // Majority red mirror.
+        assertEquals(19811L + 19811L * 19810L,
+                StageProgressionMonitor.computeTotalWorkUnits(19811, 19810, "DUAL_EDGE_CARDINALITY_WITH_SINGLES"));
+    }
+
+    @Test
+    void singlesStrategyCountsBothColorsWhenTied() {
+        assertEquals(10L + 25L,
+                StageProgressionMonitor.computeTotalWorkUnits(5, 5, "DUAL_EDGE_CARDINALITY_WITH_SINGLES"));
+    }
+
+    @Test
+    void nullStrategyFallsBackToPairs() {
+        assertEquals(25L, StageProgressionMonitor.computeTotalWorkUnits(5, 5, null));
+    }
+}


### PR DESCRIPTION
Queue-manager half of single-flip support: stage initialization computes totalPairs = majorityColorCount + red*blue for the new strategy. Logic extracted to a static method with the repo's first unit tests (spring-boot-starter-test). Inert until WORK_ENUMERATION_STRATEGY is switched. Companions: ramsey-worker-rust#64, ramsey-mw#154.

🤖 Generated with [Claude Code](https://claude.com/claude-code)