### PR TITLE
Singles count both colors in totalWorkUnits

### DIFF
--- a/src/main/java/com/setminusx/ramsey/qm/controller/StageProgressionMonitor.java
+++ b/src/main/java/com/setminusx/ramsey/qm/controller/StageProgressionMonitor.java
@@ -239,16 +239,15 @@ public class StageProgressionMonitor {
 
     /**
      * Total work units for a stage. Pair strategies use redCount * blueCount.
-     * DUAL_EDGE_CARDINALITY_WITH_SINGLES prepends one work unit per
-     * majority-color edge (both colors when tied) — this MUST match the Rust
-     * worker's DualCardinalityWithSinglesEnumerator; the worker refuses the
-     * stage if the totals disagree.
+     * DUAL_EDGE_CARDINALITY_WITH_SINGLES prepends one work unit per edge of
+     * EITHER color (singles = redCount + blueCount) — this MUST match the
+     * Rust worker's DualCardinalityWithSinglesEnumerator; the worker refuses
+     * the stage if the totals disagree.
      */
     static long computeTotalWorkUnits(long redCount, long blueCount, String strategy) {
         long pairs = redCount * blueCount;
         if ("DUAL_EDGE_CARDINALITY_WITH_SINGLES".equals(strategy)) {
-            long singles = (redCount == blueCount) ? redCount + blueCount : Math.max(redCount, blueCount);
-            return singles + pairs;
+            return redCount + blueCount + pairs;
         }
         return pairs;
     }

--- a/src/test/java/com/setminusx/ramsey/qm/controller/StageProgressionMonitorTest.java
+++ b/src/test/java/com/setminusx/ramsey/qm/controller/StageProgressionMonitorTest.java
@@ -15,12 +15,12 @@ class StageProgressionMonitorTest {
     }
 
     @Test
-    void singlesStrategyAddsMajorityColorCount() {
-        // Stage 8319 shape: 19,810 red / 19,811 blue -> majority blue.
-        assertEquals(19811L + 19810L * 19811L,
+    void singlesStrategyAddsBothColorCounts() {
+        // Stage 8319 shape: 19,810 red / 19,811 blue -> 39,621 singles.
+        assertEquals(39621L + 19810L * 19811L,
                 StageProgressionMonitor.computeTotalWorkUnits(19810, 19811, "DUAL_EDGE_CARDINALITY_WITH_SINGLES"));
-        // Majority red mirror.
-        assertEquals(19811L + 19811L * 19810L,
+        // Mirrored balance gives the identical total.
+        assertEquals(39621L + 19811L * 19810L,
                 StageProgressionMonitor.computeTotalWorkUnits(19811, 19810, "DUAL_EDGE_CARDINALITY_WITH_SINGLES"));
     }
 


### PR DESCRIPTION
QM half of the both-colors singles rule (companion: ramsey-worker-rust#65). totalPairs = R + B + R×B for DUAL_EDGE_CARDINALITY_WITH_SINGLES; unit tests updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)