### PR TITLE
Advance fully-processed stages without the exhaustion delay

### DIFF
--- a/src/main/java/com/setminusx/ramsey/qm/controller/StageProgressionMonitor.java
+++ b/src/main/java/com/setminusx/ramsey/qm/controller/StageProgressionMonitor.java
@@ -111,22 +111,34 @@ public class StageProgressionMonitor {
      * result.
      */
     private void handleExhaustedStage(Stage currentStage, Graph baseGraph, Integer stageId) {
-        Long delayMs = ramseyConfig.getStage().getExhaustionDelayMs();
+        long totalPairs = redisQueueService.getStageTotalPairs(stageId);
+        long processed = redisQueueService.getProcessedCount(stageId);
 
-        // Track when exhaustion was first detected
-        Instant detectedAt = exhaustionDetectedAt.computeIfAbsent(stageId, k -> {
-            log.info("Stage {} exhausted, starting {}ms delay before progression...", stageId, delayMs);
-            return Instant.now();
-        });
-
-        // Check if delay has passed
-        long elapsedMs = Instant.now().toEpochMilli() - detectedAt.toEpochMilli();
-        if (elapsedMs < delayMs) {
-            log.debug("Stage {} exhaustion delay: {}ms / {}ms elapsed", stageId, elapsedMs, delayMs);
-            return;
+        if (isFullyProcessed(processed, totalPairs)) {
+            // All claimed work units have been processed AND their results published (workers
+            // increment processed_count only after submitting), so there are no in-flight
+            // stragglers to wait for. Skip the exhaustion delay and advance immediately.
+            exhaustionDetectedAt.remove(stageId);
+            log.info("Stage {} fully processed ({}/{}) — advancing without exhaustion delay", stageId, processed, totalPairs);
+        } else {
+            // Work is fully claimed but not fully processed — likely a restarted/in-flight worker
+            // whose claimed units may never report. We cannot wait on processed_count forever, so
+            // wait out the exhaustion delay, then fall back to the best published result.
+            Long delayMs = ramseyConfig.getStage().getExhaustionDelayMs();
+            Instant detectedAt = exhaustionDetectedAt.computeIfAbsent(stageId, k -> {
+                log.info("Stage {} claimed-exhausted but only {}/{} processed; starting {}ms straggler delay...",
+                        stageId, processed, totalPairs, delayMs);
+                return Instant.now();
+            });
+            long elapsedMs = Instant.now().toEpochMilli() - detectedAt.toEpochMilli();
+            if (elapsedMs < delayMs) {
+                log.debug("Stage {} straggler delay: {}ms / {}ms elapsed ({}/{} processed)",
+                        stageId, elapsedMs, delayMs, processed, totalPairs);
+                return;
+            }
+            log.info("Stage {} straggler delay complete ({}/{} processed), selecting best unprocessed result...",
+                    stageId, processed, totalPairs);
         }
-
-        log.info("Stage {} exhaustion delay complete, selecting best unprocessed result...", stageId);
 
         // Get top N results
         int topCount = ramseyConfig.getStage().getTopResultsCount();
@@ -250,6 +262,16 @@ public class StageProgressionMonitor {
             return redCount + blueCount + pairs;
         }
         return pairs;
+    }
+
+    /**
+     * True when every work unit of an exhausted (fully-claimed) stage has also been processed
+     * and published, so the stage can advance immediately without waiting out the exhaustion
+     * delay. Requires a known positive total; processedCount may slightly exceed totalPairs on
+     * the final partial batch, hence the >= comparison.
+     */
+    static boolean isFullyProcessed(long processedCount, long totalPairs) {
+        return totalPairs > 0 && processedCount >= totalPairs;
     }
 
     /**

--- a/src/main/java/com/setminusx/ramsey/qm/service/RedisQueueService.java
+++ b/src/main/java/com/setminusx/ramsey/qm/service/RedisQueueService.java
@@ -29,6 +29,7 @@ public class RedisQueueService {
     private static final String BEST_RESULTS_KEY_PREFIX = "best_results:"; // Sorted set for top-N
     private static final String STAGE_WORK_INDEX_PREFIX = "stage_work_index:";
     private static final String STAGE_CONFIG_PREFIX = "stage_config:";
+    private static final String PROCESSED_COUNT_PREFIX = "processed_count:";
     private static final String PROCESSED_GRAPH_HASHES_KEY = "processed_graph_hashes";
 
     private final StringRedisTemplate redisTemplate;
@@ -86,6 +87,35 @@ public class RedisQueueService {
         String indexKey = STAGE_WORK_INDEX_PREFIX + stageId;
         String value = redisTemplate.opsForValue().get(indexKey);
         return value != null ? Long.parseLong(value) : 0L;
+    }
+
+    /**
+     * Number of work units actually processed (evaluated and results submitted) for a stage.
+     * Workers increment this only after submitting their batch results, so when it reaches
+     * totalPairs every result is already published — no in-flight stragglers remain.
+     */
+    public long getProcessedCount(Integer stageId) {
+        String value = redisTemplate.opsForValue().get(PROCESSED_COUNT_PREFIX + stageId);
+        return value != null ? Long.parseLong(value) : 0L;
+    }
+
+    /**
+     * Total work units for a stage from its Redis config, or -1 if unknown/uninitialized.
+     */
+    public long getStageTotalPairs(Integer stageId) {
+        String configJson = redisTemplate.opsForValue().get(STAGE_CONFIG_PREFIX + stageId);
+        if (configJson == null) {
+            return -1L;
+        }
+        try {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> config = objectMapper.readValue(configJson, Map.class);
+            Object totalPairsObj = config.get("totalPairs");
+            return totalPairsObj == null ? -1L : ((Number) totalPairsObj).longValue();
+        } catch (Exception e) {
+            log.error("Failed to parse stage config for totalPairs: {}", stageId, e);
+            return -1L;
+        }
     }
 
     /**
@@ -238,27 +268,8 @@ public class RedisQueueService {
      * Returns true if stage_work_index >= totalPairs from stage config.
      */
     public boolean isStageExhausted(Integer stageId) {
-        String configKey = STAGE_CONFIG_PREFIX + stageId;
-        String configJson = redisTemplate.opsForValue().get(configKey);
-
-        if (configJson == null) {
-            return false;
-        }
-
-        try {
-            @SuppressWarnings("unchecked")
-            Map<String, Object> config = objectMapper.readValue(configJson, Map.class);
-            Object totalPairsObj = config.get("totalPairs");
-            if (totalPairsObj == null) {
-                return false;
-            }
-            long totalPairs = ((Number) totalPairsObj).longValue();
-            long claimed = getStageWorkIndex(stageId);
-            return claimed >= totalPairs;
-        } catch (Exception e) {
-            log.error("Failed to parse stage config for exhaustion check: {}", stageId, e);
-            return false;
-        }
+        long totalPairs = getStageTotalPairs(stageId);
+        return totalPairs > 0 && getStageWorkIndex(stageId) >= totalPairs;
     }
 
     /**

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,6 +12,8 @@ spring:
 
 ramsey:
   campaign-id: 1
+  stage-progression:
+    frequency-in-millis: ${STAGE_PROGRESSION_FREQUENCY_MS:30000}
   stage:
     top-results-count: ${TOP_RESULTS_COUNT:10}
     exhaustion-delay-ms: ${EXHAUSTION_DELAY_MS:60000}

--- a/src/test/java/com/setminusx/ramsey/qm/controller/StageProgressionMonitorTest.java
+++ b/src/test/java/com/setminusx/ramsey/qm/controller/StageProgressionMonitorTest.java
@@ -3,6 +3,8 @@ package com.setminusx.ramsey.qm.controller;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class StageProgressionMonitorTest {
 
@@ -33,5 +35,27 @@ class StageProgressionMonitorTest {
     @Test
     void nullStrategyFallsBackToPairs() {
         assertEquals(25L, StageProgressionMonitor.computeTotalWorkUnits(5, 5, null));
+    }
+
+    @Test
+    void fullyProcessedWhenProcessedReachesTotal() {
+        long total = 39621L + 19812L * 19809L; // a real WITH_SINGLES total
+        assertTrue(StageProgressionMonitor.isFullyProcessed(total, total));
+        // Final partial batch can push processed slightly past total.
+        assertTrue(StageProgressionMonitor.isFullyProcessed(total + 250, total));
+    }
+
+    @Test
+    void notFullyProcessedWhileStragglersOutstanding() {
+        long total = 392_495_529L;
+        assertFalse(StageProgressionMonitor.isFullyProcessed(total - 1, total));
+        assertFalse(StageProgressionMonitor.isFullyProcessed(0L, total));
+    }
+
+    @Test
+    void notFullyProcessedWhenTotalUnknown() {
+        // getStageTotalPairs returns -1 when config is missing; 0 guards uninitialized stages.
+        assertFalse(StageProgressionMonitor.isFullyProcessed(100L, -1L));
+        assertFalse(StageProgressionMonitor.isFullyProcessed(100L, 0L));
     }
 }


### PR DESCRIPTION
## What
At the new faster sweep cadence (~13 min vs ~95 min, because the campaign-10 graph has ~28× fewer cliques), the fixed exhaustion delay is a meaningful fraction of each stage cycle. This advances a stage **immediately** once it is *fully processed*, and keeps the delay only for the case it was designed for.

## Why the delay exists (and when it's still needed)
The delay covers **claimed-but-never-published** work units from a worker that restarted/died mid-sweep — we can't wait on `processed` forever, so after all work is *claimed* we wait a fixed grace period then take the best published result.

But when `processed_count >= totalPairs`, every claimed unit has been processed **and** its results published (the worker increments `processed_count` only *after* `submit_results`), so there are no stragglers and nothing to wait for.

## Change
`handleExhaustedStage`:
- if `processed_count >= totalPairs` → advance now (no delay)
- else → existing `exhaustionDetectedAt` + delay fallback (the straggler case)

Plus:
- `RedisQueueService.getProcessedCount` + `getStageTotalPairs`; `isStageExhausted` refactored to reuse the latter.
- `application.yml`: poll frequency is now env-configurable (`STAGE_PROGRESSION_FREQUENCY_MS`, default 30000) so it can be cranked down (10s in the stack env).
- Unit tests for `isFullyProcessed`.

## Deploy notes (stack env, not in this repo)
- `STAGE_PROGRESSION_FREQUENCY_MS: 10000`
- `CYCLE_PREVENTION_GRAPH_LOOKBACK_COUNT: 250` (recovery-reseed insurance, larger now that the faster cadence churns more stages per wall-clock minute)

🤖 Generated with [Claude Code](https://claude.com/claude-code)