### PR TITLE
Add IMMEDIATELY_PROGRESS_STAGE_ON_IMPROVEMENT flag (default true)

### DIFF
--- a/src/main/java/com/setminusx/ramsey/qm/config/RamseyConfig.java
+++ b/src/main/java/com/setminusx/ramsey/qm/config/RamseyConfig.java
@@ -77,6 +77,14 @@ public class RamseyConfig {
          * Default: 50
          */
         private Integer cyclePreventionGraphLookbackCount = 50;
+
+        /**
+         * When true (default — current behaviour), a stage advances the moment a result beats
+         * the base graph's clique count. When false, the stage runs to exhaustion and the best
+         * result found across the whole work space is taken at the end.
+         * Env: IMMEDIATELY_PROGRESS_STAGE_ON_IMPROVEMENT
+         */
+        private boolean immediatelyProgressOnImprovement = true;
     }
 
 }

--- a/src/main/java/com/setminusx/ramsey/qm/controller/StageProgressionMonitor.java
+++ b/src/main/java/com/setminusx/ramsey/qm/controller/StageProgressionMonitor.java
@@ -67,34 +67,12 @@ public class StageProgressionMonitor {
             return;
         }
 
-        // SCENARIO 1: Check for improvement (best result better than base)
-        List<BestResult> topResults = redisQueueService.getTopResults(stageId, 1);
-        if (!topResults.isEmpty()) {
-            BestResult best = topResults.getFirst();
-            if (best.getCliqueCount() < baseGraph.getCliqueCount()) {
-                // CRITICAL: Check if this improvement would revert to a previously processed
-                // graph
-                // This prevents oscillation when exhaustion handling picks a worse graph
-                String graphHash;
-                if (best.isSimulatedAnnealingResult()) {
-                    graphHash = GraphHashUtil.computeHash(best.getGraphBitstring());
-                } else {
-                    graphHash = GraphHashUtil.computeDerivedGraphHash(baseGraph, best.getEdgesToFlip());
-                }
-
-                if (redisQueueService.isGraphAlreadyProcessed(graphHash)) {
-                    log.info("Improvement found (cliques={}) but graph already processed, treating as exhaustion case",
-                            best.getCliqueCount());
-                    // Fall through to exhaustion handling instead of progressing
-                } else {
-                    log.info("IMPROVEMENT FOUND! Stage {} base graph has {} cliques, best result has {} (source: {})",
-                            stageId, baseGraph.getCliqueCount(), best.getCliqueCount(),
-                            best.isSimulatedAnnealingResult() ? "SA" : "EXHAUSTIVE");
-                    exhaustionDetectedAt.remove(stageId); // Clear any exhaustion tracking
-                    progressStageWithHash(currentStage, baseGraph, best, graphHash);
-                    return;
-                }
-            }
+        // SCENARIO 1: improvement found (best result beats base). Only acted on when immediate
+        // progression is enabled; when disabled the stage runs to exhaustion (SCENARIO 2) and the
+        // best result across the whole work space is taken at the end.
+        if (ramseyConfig.getStage().isImmediatelyProgressOnImprovement()
+                && tryProgressOnImprovement(currentStage, baseGraph, stageId)) {
+            return;
         }
 
         // SCENARIO 2: Check for exhaustion
@@ -104,6 +82,40 @@ public class StageProgressionMonitor {
             // Not exhausted yet, clear any stale exhaustion tracking
             exhaustionDetectedAt.remove(stageId);
         }
+    }
+
+    /**
+     * SCENARIO 1: if the best result beats the base graph and hasn't already been processed,
+     * advance the stage to it. Returns true if the stage was progressed.
+     */
+    private boolean tryProgressOnImprovement(Stage currentStage, Graph baseGraph, Integer stageId) {
+        List<BestResult> topResults = redisQueueService.getTopResults(stageId, 1);
+        if (topResults.isEmpty()) {
+            return false;
+        }
+        BestResult best = topResults.getFirst();
+        if (best.getCliqueCount() >= baseGraph.getCliqueCount()) {
+            return false;
+        }
+
+        // Guard against oscillation: don't progress to a graph we've already processed
+        // (this prevents reverting when exhaustion handling picks a worse graph).
+        String graphHash = best.isSimulatedAnnealingResult()
+                ? GraphHashUtil.computeHash(best.getGraphBitstring())
+                : GraphHashUtil.computeDerivedGraphHash(baseGraph, best.getEdgesToFlip());
+
+        if (redisQueueService.isGraphAlreadyProcessed(graphHash)) {
+            log.info("Improvement found (cliques={}) but graph already processed, treating as exhaustion case",
+                    best.getCliqueCount());
+            return false; // fall through to exhaustion handling
+        }
+
+        log.info("IMPROVEMENT FOUND! Stage {} base graph has {} cliques, best result has {} (source: {})",
+                stageId, baseGraph.getCliqueCount(), best.getCliqueCount(),
+                best.isSimulatedAnnealingResult() ? "SA" : "EXHAUSTIVE");
+        exhaustionDetectedAt.remove(stageId); // Clear any exhaustion tracking
+        progressStageWithHash(currentStage, baseGraph, best, graphHash);
+        return true;
     }
 
     /**

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,3 +18,4 @@ ramsey:
     top-results-count: ${TOP_RESULTS_COUNT:10}
     exhaustion-delay-ms: ${EXHAUSTION_DELAY_MS:60000}
     cycle-prevention-graph-lookback-count: ${CYCLE_PREVENTION_GRAPH_LOOKBACK_COUNT:50}
+    immediately-progress-on-improvement: ${IMMEDIATELY_PROGRESS_STAGE_ON_IMPROVEMENT:true}

--- a/src/test/java/com/setminusx/ramsey/qm/controller/StageProgressionMonitorTest.java
+++ b/src/test/java/com/setminusx/ramsey/qm/controller/StageProgressionMonitorTest.java
@@ -1,10 +1,24 @@
 package com.setminusx.ramsey.qm.controller;
 
+import com.setminusx.ramsey.qm.client.MiddlewareClient;
+import com.setminusx.ramsey.qm.config.RamseyConfig;
+import com.setminusx.ramsey.qm.model.BestResult;
+import com.setminusx.ramsey.qm.model.Graph;
+import com.setminusx.ramsey.qm.model.Stage;
+import com.setminusx.ramsey.qm.service.RedisQueueService;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class StageProgressionMonitorTest {
 
@@ -57,5 +71,81 @@ class StageProgressionMonitorTest {
         // getStageTotalPairs returns -1 when config is missing; 0 guards uninitialized stages.
         assertFalse(StageProgressionMonitor.isFullyProcessed(100L, -1L));
         assertFalse(StageProgressionMonitor.isFullyProcessed(100L, 0L));
+    }
+
+    @Test
+    void doesNotProgressOnImprovementWhenImmediateProgressionDisabled() {
+        MiddlewareClient mw = mock(MiddlewareClient.class);
+        RedisQueueService redis = mock(RedisQueueService.class);
+        RamseyConfig config = mock(RamseyConfig.class);
+
+        RamseyConfig.Stage stageCfg = new RamseyConfig.Stage();
+        stageCfg.setImmediatelyProgressOnImprovement(false); // run to exhaustion
+        when(config.getStage()).thenReturn(stageCfg);
+        when(config.getCampaignId()).thenReturn(10);
+
+        when(mw.getStagesByCampaignIdAndStatus(10, Stage.Status.ACTIVE)).thenReturn(List.of(activeStage()));
+        when(mw.getGraphById(7)).thenReturn(baseGraph(100));
+        when(redis.getTopResults(42, 1)).thenReturn(List.of(improvement(90))); // beats base (100)
+        when(redis.isStageExhausted(42)).thenReturn(false);
+
+        new StageProgressionMonitor(mw, redis, config).checkForProgression();
+
+        // Improvement exists, but immediate progression is off and the stage isn't exhausted.
+        verify(mw, never()).createStage(any());
+        verify(mw, never()).createGraph(any());
+    }
+
+    @Test
+    void progressesOnImprovementWhenImmediateProgressionEnabled() {
+        MiddlewareClient mw = mock(MiddlewareClient.class);
+        RedisQueueService redis = mock(RedisQueueService.class);
+        RamseyConfig config = mock(RamseyConfig.class);
+
+        RamseyConfig.Stage stageCfg = new RamseyConfig.Stage(); // default: immediate progression = true
+        when(config.getStage()).thenReturn(stageCfg);
+        when(config.getCampaignId()).thenReturn(10);
+
+        when(mw.getStagesByCampaignIdAndStatus(10, Stage.Status.ACTIVE)).thenReturn(List.of(activeStage()));
+        when(mw.getGraphById(7)).thenReturn(baseGraph(100));
+        when(redis.getTopResults(42, 1)).thenReturn(List.of(improvement(90)));
+        when(redis.isGraphAlreadyProcessed(anyString())).thenReturn(false);
+
+        Graph saved = new Graph();
+        saved.setGraphId(8);
+        when(mw.createGraph(any())).thenReturn(saved);
+        Stage created = new Stage();
+        created.setStageId(43); // null strategy -> skips Redis re-init
+        when(mw.createStage(any())).thenReturn(created);
+
+        new StageProgressionMonitor(mw, redis, config).checkForProgression();
+
+        verify(mw).createStage(any()); // progressed
+    }
+
+    private static Stage activeStage() {
+        Stage s = new Stage();
+        s.setStageId(42);
+        s.setBaseGraphId(7);
+        s.setStatus(Stage.Status.ACTIVE);
+        s.setCampaignId(10);
+        return s;
+    }
+
+    private static Graph baseGraph(int cliqueCount) {
+        Graph g = new Graph();
+        g.setGraphId(7);
+        g.setCliqueCount(cliqueCount);
+        g.setVertexCount(282);
+        g.setSubgraphSize(8);
+        return g;
+    }
+
+    private static BestResult improvement(int cliqueCount) {
+        BestResult b = new BestResult();
+        b.setCliqueCount(cliqueCount);
+        b.setBaseGraphId(7);
+        b.setGraphBitstring("0101"); // SA-style result -> simple hash path
+        return b;
     }
 }


### PR DESCRIPTION
Today the stage **always** advances the instant any result beats the base graph's clique count (`StageProgressionMonitor` SCENARIO 1) — there was no way to instead run a stage to exhaustion.

Adds **`IMMEDIATELY_PROGRESS_STAGE_ON_IMPROVEMENT`** (`ramsey.stage.immediately-progress-on-improvement`, default **true**):
- **true** (default — current behaviour): advance immediately on the first improving result.
- **false**: skip the improvement check; run the stage to exhaustion and take the best result across the whole work space at the end (SCENARIO 2 already handles this).

SCENARIO 1 is extracted into `tryProgressOnImprovement(...)` and gated on the flag. Tests: existing static-helper tests plus two new ones (flag off → no progression on improvement; default on → progresses). 9/9 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)