### PR TITLE
Fix dev-profile env name for stage-progression frequency

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -18,7 +18,7 @@ ramsey:
     url: ${ramsey.mw.host}/api/ramsey/stages
     default-work-enumeration-strategy: ${WORK_ENUMERATION_STRATEGY:}
   stage-progression:
-    frequency-in-millis: ${STAGE_PROGRESSION_FREQ:30000}
+    frequency-in-millis: ${STAGE_PROGRESSION_FREQUENCY_MS:30000}
 
 spring:
   data:


### PR DESCRIPTION
Under the **dev** profile, `ramsey.stage-progression.frequency-in-millis` was bound to `${STAGE_PROGRESSION_FREQ:30000}` — a var name nothing sets — so it silently used the 30000ms default and **ignored** the compose's `STAGE_PROGRESSION_FREQUENCY_MS=1000`. (The base profile already reads `STAGE_PROGRESSION_FREQUENCY_MS`; dev overrode it with the wrong name.)

Verified empirically: the running queue-manager's stage-progression events land on a 30s grid (`:15`/`:45`), confirming the 30s fallback.

This makes dev read the same var as the base profile and the compose, so the configured value (1000 = 1s) takes effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)