### PR TITLE
Fleet abstraction Phase 1c: single campaign-agnostic queue manager

### DIFF
--- a/src/main/java/com/setminusx/ramsey/qm/client/MiddlewareClient.java
+++ b/src/main/java/com/setminusx/ramsey/qm/client/MiddlewareClient.java
@@ -52,6 +52,20 @@ public class MiddlewareClient {
 
     }
 
+    /**
+     * All ACTIVE stages across every campaign (campaignId omitted). The single
+     * campaign-agnostic QM iterates these — see the fleet abstraction plan.
+     */
+    public List<Stage> getActiveStages() {
+        String getStageUri = UriComponentsBuilder.fromUriString(stageUrl)
+                .queryParam("status", Stage.Status.ACTIVE)
+                .toUriString();
+
+        return Optional.ofNullable(restTemplate.getForObject(getStageUri, Stage[].class))
+                .map(Arrays::asList)
+                .orElse(Collections.emptyList());
+    }
+
     public List<Stage> getRecentStagesByCampaignIdAndStatus(Integer campaignId, Stage.Status status, int count) {
 
         String getStageUri = UriComponentsBuilder.fromUriString(stageUrl)

--- a/src/main/java/com/setminusx/ramsey/qm/controller/StageProgressionMonitor.java
+++ b/src/main/java/com/setminusx/ramsey/qm/controller/StageProgressionMonitor.java
@@ -48,16 +48,15 @@ public class StageProgressionMonitor {
     public void checkForProgression() {
         log.debug("Checking for stage progression");
 
-        // Get active stage for the campaign
-        List<Stage> stages = middlewareClient.getStagesByCampaignIdAndStatus(
-                ramseyConfig.getCampaignId(), Stage.Status.ACTIVE);
-
-        if (stages.size() != 1) {
-            log.debug("Expected 1 active stage, found {}", stages.size());
-            return;
+        // Single campaign-agnostic QM: progress EVERY campaign's active stage.
+        // Per-stage state (Redis keys, exhaustion tracking) is stage-scoped, so
+        // this is just a loop over the existing per-stage logic.
+        for (Stage currentStage : middlewareClient.getActiveStages()) {
+            checkStageForProgression(currentStage);
         }
+    }
 
-        Stage currentStage = stages.getFirst();
+    private void checkStageForProgression(Stage currentStage) {
         Integer stageId = currentStage.getStageId();
 
         // Get current base graph
@@ -301,27 +300,27 @@ public class StageProgressionMonitor {
      */
     @Scheduled(fixedRateString = "${ramsey.work-unit.queue.frequency-in-millis:5000}")
     public void ensureActiveStageInitialized() {
-        List<Stage> stages = middlewareClient.getStagesByCampaignIdAndStatus(ramseyConfig.getCampaignId(),
-                Stage.Status.ACTIVE);
+        // Single QM: ensure the Redis stage_config exists for EVERY campaign's
+        // active stage (safeguards against Redis data loss for any of them).
+        List<Stage> stages = middlewareClient.getActiveStages();
 
         if (stages.isEmpty()) {
             return;
         }
 
-        if (stages.size() > 1) {
-            log.warn("Expected 1 active stage, found {}. Using the first one.", stages.size());
+        for (Stage stage : stages) {
+            if (stage.getWorkEnumerationStrategy() != null) {
+                checkAndInitializeStage(stage);
+            }
         }
 
-        Stage stage = stages.getFirst();
-
-        if (stage.getWorkEnumerationStrategy() != null) {
-            checkAndInitializeStage(stage);
-        }
-
-        // Re-seed processed graph hashes independently — handles the case where only
-        // that key was lost while stage_config remained intact
+        // Re-seed processed graph hashes (global add-only set) if it was lost —
+        // reseed from the history of every live campaign.
         if (redisQueueService.isProcessedGraphHashesEmpty()) {
-            reseedProcessedGraphHashes(stage.getCampaignId());
+            stages.stream()
+                    .map(Stage::getCampaignId)
+                    .distinct()
+                    .forEach(this::reseedProcessedGraphHashes);
         }
     }
 

--- a/src/test/java/com/setminusx/ramsey/qm/controller/StageProgressionMonitorTest.java
+++ b/src/test/java/com/setminusx/ramsey/qm/controller/StageProgressionMonitorTest.java
@@ -17,6 +17,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -82,9 +83,8 @@ class StageProgressionMonitorTest {
         RamseyConfig.Stage stageCfg = new RamseyConfig.Stage();
         stageCfg.setImmediatelyProgressOnImprovement(false); // run to exhaustion
         when(config.getStage()).thenReturn(stageCfg);
-        when(config.getCampaignId()).thenReturn(10);
 
-        when(mw.getStagesByCampaignIdAndStatus(10, Stage.Status.ACTIVE)).thenReturn(List.of(activeStage()));
+        when(mw.getActiveStages()).thenReturn(List.of(activeStage()));
         when(mw.getGraphById(7)).thenReturn(baseGraph(100));
         when(redis.getTopResults(42, 1)).thenReturn(List.of(improvement(90))); // beats base (100)
         when(redis.isStageExhausted(42)).thenReturn(false);
@@ -104,9 +104,8 @@ class StageProgressionMonitorTest {
 
         RamseyConfig.Stage stageCfg = new RamseyConfig.Stage(); // default: immediate progression = true
         when(config.getStage()).thenReturn(stageCfg);
-        when(config.getCampaignId()).thenReturn(10);
 
-        when(mw.getStagesByCampaignIdAndStatus(10, Stage.Status.ACTIVE)).thenReturn(List.of(activeStage()));
+        when(mw.getActiveStages()).thenReturn(List.of(activeStage()));
         when(mw.getGraphById(7)).thenReturn(baseGraph(100));
         when(redis.getTopResults(42, 1)).thenReturn(List.of(improvement(90)));
         when(redis.isGraphAlreadyProcessed(anyString())).thenReturn(false);
@@ -121,6 +120,39 @@ class StageProgressionMonitorTest {
         new StageProgressionMonitor(mw, redis, config).checkForProgression();
 
         verify(mw).createStage(any()); // progressed
+    }
+
+    @Test
+    void progressesEveryCampaignsActiveStage() {
+        // Single campaign-agnostic QM: two active stages (different campaigns),
+        // both with an improvement, are BOTH progressed in one tick.
+        MiddlewareClient mw = mock(MiddlewareClient.class);
+        RedisQueueService redis = mock(RedisQueueService.class);
+        RamseyConfig config = mock(RamseyConfig.class);
+
+        RamseyConfig.Stage stageCfg = new RamseyConfig.Stage(); // immediate progression on
+        when(config.getStage()).thenReturn(stageCfg);
+
+        Stage stageA = new Stage();
+        stageA.setStageId(42); stageA.setBaseGraphId(7); stageA.setStatus(Stage.Status.ACTIVE); stageA.setCampaignId(10);
+        Stage stageB = new Stage();
+        stageB.setStageId(52); stageB.setBaseGraphId(17); stageB.setStatus(Stage.Status.ACTIVE); stageB.setCampaignId(11);
+        when(mw.getActiveStages()).thenReturn(List.of(stageA, stageB));
+
+        when(mw.getGraphById(7)).thenReturn(baseGraph(100));
+        Graph gB = new Graph(); gB.setGraphId(17); gB.setCliqueCount(200); gB.setVertexCount(282); gB.setSubgraphSize(8);
+        when(mw.getGraphById(17)).thenReturn(gB);
+        when(redis.getTopResults(42, 1)).thenReturn(List.of(improvement(90)));
+        when(redis.getTopResults(52, 1)).thenReturn(List.of(improvement(180)));
+        when(redis.isGraphAlreadyProcessed(anyString())).thenReturn(false);
+        Graph saved = new Graph(); saved.setGraphId(99);
+        when(mw.createGraph(any())).thenReturn(saved);
+        Stage createdStage = new Stage(); createdStage.setStageId(200); // null strategy -> skip re-init
+        when(mw.createStage(any())).thenReturn(createdStage);
+
+        new StageProgressionMonitor(mw, redis, config).checkForProgression();
+
+        verify(mw, times(2)).createStage(any()); // both campaigns progressed
     }
 
     private static Stage activeStage() {


### PR DESCRIPTION
Phase 1c of the fleet abstraction (spec: ramsey-mw `docs/investigations/fleet-abstraction-plan.md`). Makes one QM manage **all** campaigns, so it can replace the two env-pinned QMs (`ramsey-queue-manager` + `ramsey-queue-manager-mseed`).

## What
Both `@Scheduled` loops stop keying off `ramseyConfig.getCampaignId()` and iterate every campaign's active stage:
- `MiddlewareClient.getActiveStages()` — all `ACTIVE` stages (campaignId omitted).
- `checkForProgression()` loops them, delegating to the existing per-stage logic (extracted to `checkStageForProgression`). All QM state is already stage-scoped (`stage_config:{id}`, `stage_work_index:{id}`, `best_results:{id}`, exhaustion tracking), so this is a loop, not a redesign.
- `ensureActiveStageInitialized()` initializes each active stage's Redis config; on `processed_graph_hashes` loss it reseeds from **every** live campaign's history (the set is a shared add-only SHA-256 set — safe cross-campaign).

`RAMSEY_CAMPAIGN_ID` is no longer read by the QM.

## Testing
13 tests green, incl. new `progressesEveryCampaignsActiveStage` (two campaigns with improvements → both progressed in one tick). Existing single-campaign tests updated to mock `getActiveStages()`.

## Deploy step (not in this PR)
Retire the `ramsey-queue-manager-mseed` service and drop `RAMSEY_CAMPAIGN_ID` from `ramsey-queue-manager` in compose; deploy one QM. Load is trivial (≤ a few live campaigns; ticks are light counter checks).

## Ordering
Deploy after 1a (needs `/stages?status=ACTIVE` — already exists) and alongside/after 1b workers. Independent of 1d.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cb3eJkqTxaiKmUU79QQYpw