### PR TITLE
Phase 2: perturbation / ILS kick in the queue manager (disabled by default)

### DIFF
--- a/src/main/java/com/setminusx/ramsey/qm/client/MiddlewareClient.java
+++ b/src/main/java/com/setminusx/ramsey/qm/client/MiddlewareClient.java
@@ -36,6 +36,15 @@ public class MiddlewareClient {
         return restTemplate.getForObject(campaignUrl + "/" + campaignId, Campaign.class);
     }
 
+    /** Full stage history of a campaign (used by perturbation wall detection). */
+    public List<ProgressionPoint> getProgression(Integer campaignId) {
+        return Optional.ofNullable(
+                        restTemplate.getForObject(campaignUrl + "/" + campaignId + "/progression",
+                                ProgressionPoint[].class))
+                .map(Arrays::asList)
+                .orElse(Collections.emptyList());
+    }
+
     ////////////////////////////////////////////////////////////////////////////////
     // Stage //
     ////////////////////////////////////////////////////////////////////////////////

--- a/src/main/java/com/setminusx/ramsey/qm/config/RamseyConfig.java
+++ b/src/main/java/com/setminusx/ramsey/qm/config/RamseyConfig.java
@@ -21,6 +21,27 @@ public class RamseyConfig {
     private WorkUnit workUnit;
     private Campaign campaign;
     private Stage stage;
+    private Perturbation perturbation = new Perturbation();
+
+    /**
+     * Iterated-local-search "kick": when a campaign has gone {@code wallStages}
+     * stages with no new minimum, restart its descent from a randomly perturbed
+     * copy of the campaign's best (minimum) graph. See the fleet-abstraction /
+     * perturbation plan docs in ramsey-mw.
+     */
+    @Data
+    public static class Perturbation {
+        /** Off by default — enabling changes live search behavior. Env: PERTURBATION_ENABLED */
+        private boolean enabled = false;
+        /** Wall = this many stages with no new campaign minimum. Env: PERTURBATION_WALL_STAGES */
+        private int wallStages = 500;
+        /** Kick strength: flips this many red AND this many blue edges (balance-preserving). Env: PERTURBATION_EDGE_PAIRS */
+        private int edgePairs = 30;
+        /** Strength multiplier cap for consecutive fruitless kicks (1x..capx). Env: PERTURBATION_ESCALATION_CAP */
+        private int escalationCap = 4;
+        /** Attempts to find a novel (unvisited) perturbed graph before giving up this tick. */
+        private int maxNoveltyRetries = 5;
+    }
 
     @Data
     public static class Mw {

--- a/src/main/java/com/setminusx/ramsey/qm/controller/StageProgressionMonitor.java
+++ b/src/main/java/com/setminusx/ramsey/qm/controller/StageProgressionMonitor.java
@@ -5,8 +5,10 @@ import com.setminusx.ramsey.qm.config.RamseyConfig;
 import com.setminusx.ramsey.qm.model.BestResult;
 import com.setminusx.ramsey.qm.model.Edge;
 import com.setminusx.ramsey.qm.model.Graph;
+import com.setminusx.ramsey.qm.model.ProgressionPoint;
 import com.setminusx.ramsey.qm.model.Stage;
 import com.setminusx.ramsey.qm.service.RedisQueueService;
+import com.setminusx.ramsey.qm.utility.CliqueCounter;
 import com.setminusx.ramsey.qm.utility.GraphHashUtil;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -222,17 +224,26 @@ public class StageProgressionMonitor {
         Graph savedGraph = middlewareClient.createGraph(derivedGraph);
         log.info("Created new graph with ID: {}", savedGraph.getGraphId());
 
-        // 5. Mark current stage as INACTIVE
+        switchToNewStage(currentStage, savedGraph, "source: " + source);
+    }
+
+    /**
+     * Deactivate the current stage and activate a new one based on savedGraph
+     * (shared by normal progression and perturbation kicks): create stage, init
+     * Redis counters, clear the old stage's keys.
+     */
+    private Stage switchToNewStage(Stage currentStage, Graph savedGraph, String details) {
+        // Mark current stage as INACTIVE
         log.info("Marking stage {} as INACTIVE", currentStage.getStageId());
         currentStage.setStatus(Stage.Status.INACTIVE);
         middlewareClient.updateStage(currentStage);
 
-        // 6. Create new active stage with default enumeration strategy
+        // Create new active stage with default enumeration strategy
         Stage newStage = new Stage();
         newStage.setStatus(Stage.Status.ACTIVE);
         newStage.setBaseGraphId(savedGraph.getGraphId());
         newStage.setCampaignId(currentStage.getCampaignId());
-        newStage.setDetails("source: " + source);
+        newStage.setDetails(details);
 
         // Apply default work enumeration strategy if configured
         String defaultStrategy = ramseyConfig.getStage().getDefaultWorkEnumerationStrategy();
@@ -242,15 +253,15 @@ public class StageProgressionMonitor {
         }
 
         Stage createdStage = middlewareClient.createStage(newStage);
-        log.info("Created new stage {} with base graph {} (source: {})",
-                createdStage.getStageId(), savedGraph.getGraphId(), source);
+        log.info("Created new stage {} with base graph {} ({})",
+                createdStage.getStageId(), savedGraph.getGraphId(), details);
 
-        // 7. Initialize counter-based mode for new stage (before clearing old stage)
+        // Initialize counter-based mode for new stage (before clearing old stage)
         if (createdStage.getWorkEnumerationStrategy() != null) {
             initializeRedisForStage(createdStage, savedGraph);
         }
 
-        // 8. Clear Redis queue and counter keys for old stage
+        // Clear Redis queue and counter keys for old stage
         log.info("Clearing Redis keys for old stage {}", currentStage.getStageId());
         redisQueueService.clearQueue(currentStage.getStageId());
         redisQueueService.clearStageCounter(currentStage.getStageId());
@@ -258,6 +269,167 @@ public class StageProgressionMonitor {
         redisQueueService.deleteTopResults(currentStage.getStageId());
 
         log.info("Stage progression complete! New stage {} is now active", createdStage.getStageId());
+        return createdStage;
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////
+    // Perturbation (Iterated Local Search "kick") //
+    ////////////////////////////////////////////////////////////////////////////////
+
+    // Per-campaign: the stage id of the last kick, and how many consecutive kicks
+    // have happened without a new campaign minimum (drives escalation). In-memory:
+    // after a QM restart the worst case is one early re-kick of a walled campaign,
+    // which is harmless (kicks always start from the campaign-minimum incumbent).
+    private final Map<Integer, Integer> lastKickStageId = new ConcurrentHashMap<>();
+    private final Map<Integer, Integer> fruitlessKicks = new ConcurrentHashMap<>();
+    private final java.util.Random perturbationRandom = new java.util.Random();
+
+    /**
+     * ILS kick: when a campaign has gone {@code wallStages} stages with no new
+     * minimum, restart its descent from a randomly perturbed (balance-preserving)
+     * copy of the campaign's BEST graph — the incumbent, never the drifted current
+     * base. Consecutive fruitless kicks escalate the kick strength.
+     */
+    @Scheduled(fixedRateString = "${ramsey.perturbation.frequency-in-millis:300000}")
+    public void checkForPerturbation() {
+        if (!ramseyConfig.getPerturbation().isEnabled()) {
+            return;
+        }
+        for (Stage stage : middlewareClient.getActiveStages()) {
+            try {
+                maybePerturbCampaign(stage);
+            } catch (Exception e) {
+                log.warn("Perturbation check failed for campaign {}: {}", stage.getCampaignId(), e.toString());
+            }
+        }
+    }
+
+    private void maybePerturbCampaign(Stage currentStage) {
+        RamseyConfig.Perturbation cfg = ramseyConfig.getPerturbation();
+        Integer campaignId = currentStage.getCampaignId();
+
+        List<ProgressionPoint> history = middlewareClient.getProgression(campaignId);
+        if (history.size() < cfg.getWallStages()) {
+            return; // too young to be walled
+        }
+
+        // Campaign minimum (the incumbent) and the first stage that achieved it.
+        ProgressionPoint minPoint = history.stream()
+                .filter(p -> p.getCliqueCount() != null)
+                .min(java.util.Comparator.comparingLong(ProgressionPoint::getCliqueCount)
+                        .thenComparing(ProgressionPoint::getStageId))
+                .orElse(null);
+        if (minPoint == null) {
+            return;
+        }
+
+        long stagesSinceMin = history.stream()
+                .filter(p -> p.getStageId() > minPoint.getStageId())
+                .count();
+        if (stagesSinceMin < cfg.getWallStages()) {
+            resetKickTrackingIfImproved(campaignId, minPoint.getStageId());
+            return; // not walled
+        }
+
+        // Don't re-kick until another full wall has elapsed since the last kick.
+        Integer lastKick = lastKickStageId.get(campaignId);
+        if (lastKick != null) {
+            long stagesSinceKick = history.stream().filter(p -> p.getStageId() > lastKick).count();
+            if (stagesSinceKick < cfg.getWallStages()) {
+                return;
+            }
+            // The previous kick produced no new min (min stage predates the kick) -> escalate.
+            if (minPoint.getStageId() < lastKick) {
+                fruitlessKicks.merge(campaignId, 1, Integer::sum);
+            } else {
+                fruitlessKicks.remove(campaignId);
+            }
+        }
+
+        int multiplier = Math.min(fruitlessKicks.getOrDefault(campaignId, 0) + 1, cfg.getEscalationCap());
+        int pairs = cfg.getEdgePairs() * multiplier;
+
+        Graph incumbent = middlewareClient.getGraphById(minPoint.getBaseGraphId());
+        if (incumbent == null || incumbent.getEdgeData() == null) {
+            log.warn("Perturbation: could not fetch incumbent graph {} for campaign {}",
+                    minPoint.getBaseGraphId(), campaignId);
+            return;
+        }
+
+        log.info("PERTURBATION: campaign {} walled ({} stages past min {} @ stage {}); kicking incumbent "
+                        + "graph {} with {} edge pairs (escalation x{})",
+                campaignId, stagesSinceMin, minPoint.getCliqueCount(), minPoint.getStageId(),
+                incumbent.getGraphId(), pairs, multiplier);
+
+        perturbAndAdvance(currentStage, incumbent, pairs, multiplier);
+    }
+
+    private void resetKickTrackingIfImproved(Integer campaignId, Integer minStageId) {
+        Integer lastKick = lastKickStageId.get(campaignId);
+        if (lastKick != null && minStageId > lastKick) {
+            fruitlessKicks.remove(campaignId); // the kick paid off
+        }
+    }
+
+    private void perturbAndAdvance(Stage currentStage, Graph incumbent, int pairs, int multiplier) {
+        RamseyConfig.Perturbation cfg = ramseyConfig.getPerturbation();
+
+        for (int attempt = 1; attempt <= cfg.getMaxNoveltyRetries(); attempt++) {
+            String kicked = perturbBalanced(incumbent.getEdgeData(), pairs, perturbationRandom);
+            String hash = GraphHashUtil.computeHash(kicked);
+            if (redisQueueService.isGraphAlreadyProcessed(hash)) {
+                log.info("Perturbation attempt {}: kicked graph already visited, retrying", attempt);
+                continue;
+            }
+
+            long cliqueCount = CliqueCounter.countMonoCliques(
+                    kicked, incumbent.getVertexCount(), incumbent.getSubgraphSize());
+
+            Graph kickedGraph = new Graph();
+            kickedGraph.setEdgeData(kicked);
+            kickedGraph.setVertexCount(incumbent.getVertexCount());
+            kickedGraph.setSubgraphSize(incumbent.getSubgraphSize());
+            kickedGraph.setCliqueCount((int) cliqueCount);
+
+            redisQueueService.addProcessedGraphHash(hash);
+            Graph savedGraph = middlewareClient.createGraph(kickedGraph);
+            log.info("PERTURBATION: kicked graph saved as {} (cliques {} vs incumbent {})",
+                    savedGraph.getGraphId(), cliqueCount, incumbent.getCliqueCount());
+
+            Stage created = switchToNewStage(currentStage, savedGraph,
+                    "PERTURBATION kick from graph " + incumbent.getGraphId()
+                            + " (" + incumbent.getCliqueCount() + "), pairs=" + pairs
+                            + ", escalation=x" + multiplier);
+            lastKickStageId.put(currentStage.getCampaignId(), created.getStageId());
+            return;
+        }
+        log.warn("Perturbation: no novel kicked graph found for campaign {} after {} attempts",
+                currentStage.getCampaignId(), cfg.getMaxNoveltyRetries());
+    }
+
+    /**
+     * Balance-preserving random kick: flip {@code pairs} red edges to blue and the
+     * same number of blue edges to red (the production engine's move-class invariant).
+     */
+    static String perturbBalanced(String bits, int pairs, java.util.Random random) {
+        char[] chars = bits.toCharArray();
+        List<Integer> redIdx = new java.util.ArrayList<>();
+        List<Integer> blueIdx = new java.util.ArrayList<>();
+        for (int i = 0; i < chars.length; i++) {
+            if (chars[i] == '1') {
+                redIdx.add(i);
+            } else {
+                blueIdx.add(i);
+            }
+        }
+        int p = Math.min(pairs, Math.min(redIdx.size(), blueIdx.size()));
+        java.util.Collections.shuffle(redIdx, random);
+        java.util.Collections.shuffle(blueIdx, random);
+        for (int i = 0; i < p; i++) {
+            chars[redIdx.get(i)] = '0';
+            chars[blueIdx.get(i)] = '1';
+        }
+        return new String(chars);
     }
 
     /**

--- a/src/main/java/com/setminusx/ramsey/qm/model/ProgressionPoint.java
+++ b/src/main/java/com/setminusx/ramsey/qm/model/ProgressionPoint.java
@@ -1,0 +1,13 @@
+package com.setminusx.ramsey.qm.model;
+
+import lombok.Data;
+
+/** One stage of a campaign's history, as returned by GET /campaigns/{id}/progression. */
+@Data
+public class ProgressionPoint {
+    private Integer stageId;
+    private Integer baseGraphId;
+    private Long cliqueCount;
+    private String createdDate;
+    private String status;
+}

--- a/src/main/java/com/setminusx/ramsey/qm/utility/CliqueCounter.java
+++ b/src/main/java/com/setminusx/ramsey/qm/utility/CliqueCounter.java
@@ -1,0 +1,126 @@
+package com.setminusx.ramsey.qm.utility;
+
+/**
+ * Monochromatic k-clique counter over the upper-triangular edge bitstring
+ * ('1' = red, '0' = blue) — a Java port of the Rust worker's counting kernel
+ * (ramsey-worker-rust algorithm.rs: depth parameter, leaf popcount shortcut,
+ * k-2 level inline; counts ALL k-cliques, NO pivoting — pivoting would break
+ * all-clique counting). Used once per perturbation kick to stamp the perturbed
+ * graph's true clique_count, which stage-progression comparisons depend on.
+ *
+ * Perf: a full 282-vertex count runs in low seconds — fine for once-per-kick,
+ * do NOT put this on any hot path.
+ */
+public final class CliqueCounter {
+
+    private CliqueCounter() {
+    }
+
+    /** Total monochromatic k-cliques (red + blue) of the coloring. */
+    public static long countMonoCliques(String bits, int vertexCount, int cliqueSize) {
+        int expected = vertexCount * (vertexCount - 1) / 2;
+        if (bits.length() != expected) {
+            throw new IllegalArgumentException(
+                    "bitstring length " + bits.length() + " != C(" + vertexCount + ",2) = " + expected);
+        }
+        int words = (vertexCount + 63) >>> 6;
+        long[][] red = new long[vertexCount][words];
+        long[][] blue = new long[vertexCount][words];
+
+        // blue starts as "all vertices except self", red empty; each '1' edge
+        // moves the pair from blue to red.
+        for (int i = 0; i < vertexCount; i++) {
+            for (int j = 0; j < vertexCount; j++) {
+                if (i != j) {
+                    blue[i][j >>> 6] |= 1L << (j & 63);
+                }
+            }
+        }
+        int idx = 0;
+        for (int i = 0; i < vertexCount; i++) {
+            for (int j = i + 1; j < vertexCount; j++, idx++) {
+                if (bits.charAt(idx) == '1') {
+                    red[i][j >>> 6] |= 1L << (j & 63);
+                    red[j][i >>> 6] |= 1L << (i & 63);
+                    blue[i][j >>> 6] &= ~(1L << (j & 63));
+                    blue[j][i >>> 6] &= ~(1L << (i & 63));
+                }
+            }
+        }
+        return countColor(red, vertexCount, cliqueSize, words)
+                + countColor(blue, vertexCount, cliqueSize, words);
+    }
+
+    private static long countColor(long[][] adjacency, int vertexCount, int cliqueSize, int words) {
+        long[] p = new long[words];
+        for (int v = 0; v < vertexCount; v++) {
+            p[v >>> 6] |= 1L << (v & 63);
+        }
+        return bk(0, p, adjacency, cliqueSize, words);
+    }
+
+    /**
+     * Count all k-cliques: depth = committed vertices; duplicates prevented by the
+     * shrinking candidate set (no R/X needed — see the Rust kernel's doc comments).
+     */
+    private static long bk(int depth, long[] p, long[][] adjacency, int cliqueSize, int words) {
+        if (depth == cliqueSize) {
+            return 1;
+        }
+        int pCard = cardinality(p);
+        if (depth == cliqueSize - 1) {
+            return pCard; // leaf shortcut: each candidate completes one clique
+        }
+        if (depth + pCard < cliqueSize) {
+            return 0;
+        }
+        if (depth == cliqueSize - 2) {
+            // k-2 inline: each child takes the leaf shortcut; AND + popcount per candidate.
+            long count = 0;
+            long[] candidates = p.clone();
+            for (int w = 0; w < words; w++) {
+                long word = candidates[w];
+                while (word != 0) {
+                    int v = (w << 6) + Long.numberOfTrailingZeros(word);
+                    word &= word - 1;
+                    count += intersectCardinality(p, adjacency[v], words);
+                    p[v >>> 6] &= ~(1L << (v & 63));
+                }
+            }
+            return count;
+        }
+
+        long count = 0;
+        long[] candidates = p.clone();
+        for (int w = 0; w < words; w++) {
+            long word = candidates[w];
+            while (word != 0) {
+                int v = (w << 6) + Long.numberOfTrailingZeros(word);
+                word &= word - 1;
+                long[] newP = new long[words];
+                for (int i = 0; i < words; i++) {
+                    newP[i] = p[i] & adjacency[v][i];
+                }
+                count += bk(depth + 1, newP, adjacency, cliqueSize, words);
+                p[v >>> 6] &= ~(1L << (v & 63));
+            }
+        }
+        return count;
+    }
+
+    private static int cardinality(long[] set) {
+        int c = 0;
+        for (long w : set) {
+            c += Long.bitCount(w);
+        }
+        return c;
+    }
+
+    private static long intersectCardinality(long[] a, long[] b, int words) {
+        long c = 0;
+        for (int i = 0; i < words; i++) {
+            c += Long.bitCount(a[i] & b[i]);
+        }
+        return c;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,3 +19,10 @@ ramsey:
     exhaustion-delay-ms: ${EXHAUSTION_DELAY_MS:60000}
     cycle-prevention-graph-lookback-count: ${CYCLE_PREVENTION_GRAPH_LOOKBACK_COUNT:50}
     immediately-progress-on-improvement: ${IMMEDIATELY_PROGRESS_STAGE_ON_IMPROVEMENT:true}
+  perturbation:
+    enabled: ${PERTURBATION_ENABLED:false}
+    wall-stages: ${PERTURBATION_WALL_STAGES:500}
+    edge-pairs: ${PERTURBATION_EDGE_PAIRS:30}
+    escalation-cap: ${PERTURBATION_ESCALATION_CAP:4}
+    max-novelty-retries: ${PERTURBATION_MAX_NOVELTY_RETRIES:5}
+    frequency-in-millis: ${PERTURBATION_CHECK_FREQUENCY_MS:300000}

--- a/src/test/java/com/setminusx/ramsey/qm/controller/PerturbationTest.java
+++ b/src/test/java/com/setminusx/ramsey/qm/controller/PerturbationTest.java
@@ -1,0 +1,170 @@
+package com.setminusx.ramsey.qm.controller;
+
+import com.setminusx.ramsey.qm.client.MiddlewareClient;
+import com.setminusx.ramsey.qm.config.RamseyConfig;
+import com.setminusx.ramsey.qm.model.Graph;
+import com.setminusx.ramsey.qm.model.ProgressionPoint;
+import com.setminusx.ramsey.qm.model.Stage;
+import com.setminusx.ramsey.qm.service.RedisQueueService;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+class PerturbationTest {
+
+    // ---------- perturbBalanced (pure) ----------
+
+    @Test
+    void perturbBalanced_preservesRedBlueCounts() {
+        String bits = "1".repeat(20) + "0".repeat(25);
+        String kicked = StageProgressionMonitor.perturbBalanced(bits, 7, new Random(1));
+        assertEquals(count(bits, '1'), count(kicked, '1'));
+        assertEquals(count(bits, '0'), count(kicked, '0'));
+        assertNotEquals(bits, kicked);
+        // exactly 2*pairs positions differ
+        int diff = 0;
+        for (int i = 0; i < bits.length(); i++) {
+            if (bits.charAt(i) != kicked.charAt(i)) diff++;
+        }
+        assertEquals(14, diff);
+    }
+
+    @Test
+    void perturbBalanced_capsAtAvailableEdges() {
+        String bits = "10"; // 1 red, 1 blue
+        String kicked = StageProgressionMonitor.perturbBalanced(bits, 99, new Random(1));
+        assertEquals(1, count(kicked, '1'));
+    }
+
+    // ---------- wall detection / kick behavior ----------
+
+    private RamseyConfig config(boolean enabled, int wallStages) {
+        RamseyConfig config = mock(RamseyConfig.class);
+        RamseyConfig.Perturbation p = new RamseyConfig.Perturbation();
+        p.setEnabled(enabled);
+        p.setWallStages(wallStages);
+        p.setEdgePairs(2);
+        lenient().when(config.getPerturbation()).thenReturn(p);
+        RamseyConfig.Stage stageCfg = new RamseyConfig.Stage();
+        lenient().when(config.getStage()).thenReturn(stageCfg);
+        return config;
+    }
+
+    private Stage activeStage(int stageId, int campaignId) {
+        Stage s = new Stage();
+        s.setStageId(stageId);
+        s.setBaseGraphId(stageId);
+        s.setCampaignId(campaignId);
+        s.setStatus(Stage.Status.ACTIVE);
+        return s;
+    }
+
+    /** history: min at minStage, then wallLength stages after it. */
+    private List<ProgressionPoint> walledHistory(int minStageId, long minClique, int wallLength) {
+        List<ProgressionPoint> h = new ArrayList<>();
+        for (int i = 1; i < minStageId; i++) {
+            h.add(point(i, minClique + 100 + i));
+        }
+        h.add(point(minStageId, minClique));
+        for (int i = 1; i <= wallLength; i++) {
+            h.add(point(minStageId + i, minClique + 50));
+        }
+        return h;
+    }
+
+    private ProgressionPoint point(int stageId, long clique) {
+        ProgressionPoint p = new ProgressionPoint();
+        p.setStageId(stageId);
+        p.setBaseGraphId(stageId);
+        p.setCliqueCount(clique);
+        return p;
+    }
+
+    @Test
+    void disabled_doesNothing() {
+        MiddlewareClient mw = mock(MiddlewareClient.class);
+        RedisQueueService redis = mock(RedisQueueService.class);
+        new StageProgressionMonitor(mw, redis, config(false, 500)).checkForPerturbation();
+        verifyNoInteractions(mw);
+    }
+
+    @Test
+    void notWalled_noKick() {
+        MiddlewareClient mw = mock(MiddlewareClient.class);
+        RedisQueueService redis = mock(RedisQueueService.class);
+        when(mw.getActiveStages()).thenReturn(List.of(activeStage(600, 3)));
+        when(mw.getProgression(3)).thenReturn(walledHistory(400, 1000, 100)); // wall only 100 < 500
+
+        new StageProgressionMonitor(mw, redis, config(true, 500)).checkForPerturbation();
+
+        verify(mw, never()).createGraph(any());
+        verify(mw, never()).createStage(any());
+    }
+
+    @Test
+    void walled_kicksFromIncumbentMinGraph() {
+        MiddlewareClient mw = mock(MiddlewareClient.class);
+        RedisQueueService redis = mock(RedisQueueService.class);
+        Stage current = activeStage(1000, 3);
+        when(mw.getActiveStages()).thenReturn(List.of(current));
+        when(mw.getProgression(3)).thenReturn(walledHistory(400, 1000, 600)); // wall 600 >= 500
+
+        // incumbent = min stage's base graph (id 400), K5 bitstring for a real count
+        Graph incumbent = new Graph();
+        incumbent.setGraphId(400);
+        incumbent.setEdgeData("1".repeat(10));
+        incumbent.setVertexCount(5);
+        incumbent.setSubgraphSize(5);
+        incumbent.setCliqueCount(1);
+        when(mw.getGraphById(400)).thenReturn(incumbent);
+
+        when(redis.isGraphAlreadyProcessed(anyString())).thenReturn(false);
+        Graph saved = new Graph();
+        saved.setGraphId(9000);
+        when(mw.createGraph(any())).thenReturn(saved);
+        Stage created = new Stage();
+        created.setStageId(1001); // null strategy -> skip redis init
+        when(mw.createStage(any())).thenReturn(created);
+
+        new StageProgressionMonitor(mw, redis, config(true, 500)).checkForPerturbation();
+
+        // kicked from graph 400 (the incumbent), NOT the current stage's base (1000)
+        verify(mw).getGraphById(400);
+        verify(mw).createGraph(any());
+        verify(mw).createStage(any());
+        verify(redis).addProcessedGraphHash(anyString());
+        // old stage deactivated
+        assertEquals(Stage.Status.INACTIVE, current.getStatus());
+    }
+
+    @Test
+    void walled_butAllKicksVisited_givesUpGracefully() {
+        MiddlewareClient mw = mock(MiddlewareClient.class);
+        RedisQueueService redis = mock(RedisQueueService.class);
+        when(mw.getActiveStages()).thenReturn(List.of(activeStage(1000, 3)));
+        when(mw.getProgression(3)).thenReturn(walledHistory(400, 1000, 600));
+        Graph incumbent = new Graph();
+        incumbent.setGraphId(400);
+        incumbent.setEdgeData("1".repeat(10));
+        incumbent.setVertexCount(5);
+        incumbent.setSubgraphSize(5);
+        when(mw.getGraphById(400)).thenReturn(incumbent);
+        when(redis.isGraphAlreadyProcessed(anyString())).thenReturn(true); // everything visited
+
+        new StageProgressionMonitor(mw, redis, config(true, 500)).checkForPerturbation();
+
+        verify(mw, never()).createGraph(any());
+        verify(mw, never()).createStage(any());
+    }
+
+    private static int count(String s, char c) {
+        return (int) s.chars().filter(x -> x == c).count();
+    }
+}

--- a/src/test/java/com/setminusx/ramsey/qm/utility/CliqueCounterTest.java
+++ b/src/test/java/com/setminusx/ramsey/qm/utility/CliqueCounterTest.java
@@ -1,0 +1,84 @@
+package com.setminusx.ramsey.qm.utility;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CliqueCounterTest {
+
+    @Test
+    void k5AllRedHasExactlyOneMono5Clique() {
+        assertEquals(1, CliqueCounter.countMonoCliques("1".repeat(10), 5, 5));
+    }
+
+    @Test
+    void empty5HasOneBlue5Clique() {
+        assertEquals(1, CliqueCounter.countMonoCliques("0".repeat(10), 5, 5));
+    }
+
+    @Test
+    void k4CannotContain5Cliques() {
+        assertEquals(0, CliqueCounter.countMonoCliques("1".repeat(6), 4, 5));
+    }
+
+    @Test
+    void k8AllRedCounts5CliquesAsBinomial() {
+        // C(8,5) = 56 red; complement empty
+        assertEquals(56, CliqueCounter.countMonoCliques("1".repeat(28), 8, 5));
+    }
+
+    @Test
+    void matchesBruteForceOnRandomSmallGraphs() {
+        Random r = new Random(42);
+        for (int trial = 0; trial < 20; trial++) {
+            int n = 8;
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < n * (n - 1) / 2; i++) {
+                sb.append(r.nextBoolean() ? '1' : '0');
+            }
+            String bits = sb.toString();
+            for (int k = 3; k <= 5; k++) {
+                assertEquals(bruteForce(bits, n, k), CliqueCounter.countMonoCliques(bits, n, k),
+                        "mismatch bits=" + bits + " k=" + k);
+            }
+        }
+    }
+
+    /** Enumerate every k-subset; count monochromatic ones. Reference implementation. */
+    private static long bruteForce(String bits, int n, int k) {
+        boolean[][] red = new boolean[n][n];
+        int idx = 0;
+        for (int i = 0; i < n; i++) {
+            for (int j = i + 1; j < n; j++, idx++) {
+                red[i][j] = red[j][i] = bits.charAt(idx) == '1';
+            }
+        }
+        int[] subset = new int[k];
+        return countSubsets(red, n, k, 0, 0, subset);
+    }
+
+    private static long countSubsets(boolean[][] red, int n, int k, int depth, int start, int[] subset) {
+        if (depth == k) {
+            boolean allRed = true;
+            boolean allBlue = true;
+            for (int a = 0; a < k && (allRed || allBlue); a++) {
+                for (int b = a + 1; b < k; b++) {
+                    if (red[subset[a]][subset[b]]) {
+                        allBlue = false;
+                    } else {
+                        allRed = false;
+                    }
+                }
+            }
+            return (allRed ? 1 : 0) + (allBlue ? 1 : 0);
+        }
+        long c = 0;
+        for (int v = start; v < n; v++) {
+            subset[depth] = v;
+            c += countSubsets(red, n, k, depth + 1, v + 1, subset);
+        }
+        return c;
+    }
+}


### PR DESCRIPTION
Iterated Local Search "kick" in the QM: when a campaign walls, restart its descent from a perturbed copy of its best graph. Builds on the fleet abstraction (single campaign-agnostic QM). **Shipped OFF by default** — enabling changes live search behavior and both current campaigns would kick immediately (they're already >500 stages past their mins).

## Behavior
- `checkForPerturbation` (@Scheduled, every 5 min) loops all active campaigns.
- **Wall** = a campaign has gone `PERTURBATION_WALL_STAGES` (default **500**) stages with no new *campaign minimum*.
- **Kick** = restart from a **balance-preserving** random perturbation of the campaign's **incumbent min graph** (not the drifted current base): flip `PERTURBATION_EDGE_PAIRS` (default 30) red edges to blue and the same number blue→red.
- **Escalation:** consecutive kicks that produce no new min ramp the strength (1x…`escalation-cap`, default 4x) — probes for a workable "temperature."
- **Novelty:** the kicked graph must be unvisited (`processed_graph_hashes`); retries up to `max-novelty-retries`, else waits for the next tick.
- A new `CliqueCounter` (Java port of the Rust kernel — depth param, leaf popcount shortcut, k-2 inline, **no pivoting**) stamps the kicked graph's true clique count, which progression comparisons need. **Validated live against graph 8644 = 25,840 in ~1s**; runs once per kick only.

## Config (`ramsey.perturbation.*`, all env-overridable)
`enabled=false`, `wall-stages=500`, `edge-pairs=30`, `escalation-cap=4`, `max-novelty-retries=5`, `frequency-in-millis=300000`.

## Testing
24 tests green: `CliqueCounter` vs brute force on random graphs + known K5/K8 counts; wall detection (not-walled → no kick); kick-from-incumbent (uses the min-stage graph, not current); balance preservation; graceful give-up when all kicks are visited.

## Before enabling (tuning note)
The cheap "what kick size *k* escapes the 25,840 basin" probe (per the plan) should inform `edge-pairs`/`escalation-cap` — mild kicks likely snap back to the same basin (the incumbent is certified locally optimal to |F|≤128 sampled windows). Enable per-campaign intent once tuned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cb3eJkqTxaiKmUU79QQYpw