### PR TITLE
Kick on basin staleness, and announce stage advances

### DIFF
--- a/src/main/java/com/setminusx/ramsey/qm/config/RamseyConfig.java
+++ b/src/main/java/com/setminusx/ramsey/qm/config/RamseyConfig.java
@@ -24,17 +24,24 @@ public class RamseyConfig {
     private Perturbation perturbation = new Perturbation();
 
     /**
-     * Iterated-local-search "kick": when a campaign has gone {@code wallStages}
-     * stages with no new minimum, restart its descent from a randomly perturbed
-     * copy of the campaign's best (minimum) graph. See the fleet-abstraction /
-     * perturbation plan docs in ramsey-mw.
+     * Iterated-local-search "kick": when the current basin has gone {@code basinStaleStages}
+     * stages without improving on its own floor, restart the descent from a randomly perturbed
+     * copy of the campaign's best (minimum) graph. See the fleet-abstraction / perturbation plan
+     * docs in ramsey-mw.
      */
     @Data
     public static class Perturbation {
         /** Off by default — enabling changes live search behavior. Env: PERTURBATION_ENABLED */
         private boolean enabled = false;
-        /** Wall = this many stages with no new campaign minimum. Env: PERTURBATION_WALL_STAGES */
-        private int wallStages = 500;
+        /**
+         * Kick when the current basin has gone this many stages without beating its own floor.
+         * The clock runs from the basin's BEST stage, not from the kick, so however long a
+         * descent takes it is never interrupted while it is still finding new minima — only
+         * once it flattens. Replaces the old fixed {@code PERTURBATION_WALL_STAGES} count of
+         * stages since the kick, which truncated descents that were still in free fall.
+         * Env: PERTURBATION_BASIN_STALE_STAGES
+         */
+        private int basinStaleStages = 100;
         /** Base kick strength: flips this many red AND this many blue edges (balance-preserving). Env: PERTURBATION_EDGE_PAIRS */
         private int edgePairs = 60;
         /** Max strength multiplier. Consecutive fruitless kicks escalate GEOMETRICALLY (x1,x2,x4,x8,...)

--- a/src/main/java/com/setminusx/ramsey/qm/config/RamseyConfig.java
+++ b/src/main/java/com/setminusx/ramsey/qm/config/RamseyConfig.java
@@ -88,6 +88,17 @@ public class RamseyConfig {
         private Integer topResultsCount = 10;
 
         /**
+         * Settle window: how long to keep searching after a worker announces the first new best
+         * for a stage, before adopting the best result available. Workers publish new bests on
+         * Redis pub/sub, so this decouples "when we learn" from "how long we wait" — with plain
+         * polling the settle time is random (0..poll interval) and the poll interval also floors
+         * the stage duration. Measured tradeoff: adopting sooner yields more stages but weaker
+         * steps (200ms poll = +28% stages, -31% cliques/stage, net worse than 1000ms).
+         * 0 disables the timer, leaving pure polling. Env: STAGE_ADOPT_SETTLE_MS
+         */
+        private long adoptSettleMs = 0;
+
+        /**
          * Delay in milliseconds after stage exhaustion before progressing.
          * Allows in-flight work to complete. Default: 60000 (60 seconds)
          */

--- a/src/main/java/com/setminusx/ramsey/qm/config/RamseyConfig.java
+++ b/src/main/java/com/setminusx/ramsey/qm/config/RamseyConfig.java
@@ -35,10 +35,11 @@ public class RamseyConfig {
         private boolean enabled = false;
         /** Wall = this many stages with no new campaign minimum. Env: PERTURBATION_WALL_STAGES */
         private int wallStages = 500;
-        /** Kick strength: flips this many red AND this many blue edges (balance-preserving). Env: PERTURBATION_EDGE_PAIRS */
-        private int edgePairs = 30;
-        /** Strength multiplier cap for consecutive fruitless kicks (1x..capx). Env: PERTURBATION_ESCALATION_CAP */
-        private int escalationCap = 4;
+        /** Base kick strength: flips this many red AND this many blue edges (balance-preserving). Env: PERTURBATION_EDGE_PAIRS */
+        private int edgePairs = 60;
+        /** Max strength multiplier. Consecutive fruitless kicks escalate GEOMETRICALLY (x1,x2,x4,x8,...)
+         *  capped here, so pairs run edgePairs * {1,2,4,...} up to edgePairs*cap. Env: PERTURBATION_ESCALATION_CAP */
+        private int escalationCap = 32;
         /** Attempts to find a novel (unvisited) perturbed graph before giving up this tick. */
         private int maxNoveltyRetries = 5;
     }

--- a/src/main/java/com/setminusx/ramsey/qm/config/RedisListenerConfig.java
+++ b/src/main/java/com/setminusx/ramsey/qm/config/RedisListenerConfig.java
@@ -1,0 +1,51 @@
+package com.setminusx.ramsey.qm.config;
+
+import com.setminusx.ramsey.qm.controller.StageAdoptScheduler;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+
+import java.nio.charset.StandardCharsets;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Subscribes to the workers' new-best announcements so the queue manager can arm a settle timer
+ * the moment an improvement exists, instead of discovering it on its next poll.
+ *
+ * <p>Pub/sub is fire-and-forget with no delivery guarantee, which is fine: the scheduled
+ * progression loop remains the fallback, so a dropped message costs latency, never correctness.
+ */
+@Slf4j
+@Configuration
+public class RedisListenerConfig {
+
+    /** Must match the Rust worker's redis_client::BEST_RESULT_CHANNEL. */
+    public static final String BEST_RESULT_CHANNEL = "best_result_events";
+
+    /** Payload is {"stageId":N,"cliqueCount":M}; only the stage id drives the timer. */
+    private static final Pattern STAGE_ID = Pattern.compile("\"stageId\"\\s*:\\s*(\\d+)");
+
+    @Bean
+    public RedisMessageListenerContainer bestResultListenerContainer(
+            RedisConnectionFactory connectionFactory, StageAdoptScheduler adoptScheduler) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+        MessageListener listener = (message, pattern) -> {
+            String body = new String(message.getBody(), StandardCharsets.UTF_8);
+            Matcher m = STAGE_ID.matcher(body);
+            if (m.find()) {
+                adoptScheduler.onNewBest(Integer.parseInt(m.group(1)));
+            } else {
+                log.warn("Unparseable best-result event: {}", body);
+            }
+        };
+        container.addMessageListener(listener, new ChannelTopic(BEST_RESULT_CHANNEL));
+        log.info("Subscribed to Redis channel {} for new-best announcements", BEST_RESULT_CHANNEL);
+        return container;
+    }
+}

--- a/src/main/java/com/setminusx/ramsey/qm/controller/StageAdoptScheduler.java
+++ b/src/main/java/com/setminusx/ramsey/qm/controller/StageAdoptScheduler.java
@@ -1,0 +1,74 @@
+package com.setminusx.ramsey.qm.controller;
+
+import com.setminusx.ramsey.qm.config.RamseyConfig;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Arms a per-stage "settle timer" when a worker announces the first new best for that stage.
+ *
+ * <p>Why a timer at all, given we now get a pub/sub event? Because the first announced best is
+ * usually the <em>weakest</em> qualifying improvement — some worker found a flip removing a few
+ * hundred cliques milliseconds into the stage. Adopting on that event commits to a small step.
+ * Waiting lets the fleet turn up a better one. Measured: shortening the adopt latency from
+ * ~1000ms to ~200ms produced +28% stages but -31% cliques/stage, a net loss.
+ *
+ * <p>So the event and the wait do different jobs: pub/sub removes the random discovery lag (with
+ * plain polling the settle time is uniform 0..pollInterval AND the poll interval floors the stage
+ * duration), while the timer deliberately buys step quality. Together they give the settle window
+ * that measured best at roughly half the cycle time.
+ *
+ * <p>Only the first event per stage arms the timer — workers publish on every record-break, which
+ * is many times per stage. The arm is released when the timer fires, so a stage that wasn't
+ * advanced (e.g. the candidate turned out to be already visited) can be re-armed by a later event.
+ */
+@Slf4j
+@Component
+public class StageAdoptScheduler {
+
+    private final TaskScheduler taskScheduler;
+    private final StageProgressionMonitor progressionMonitor;
+    private final RamseyConfig ramseyConfig;
+
+    /** Stages with a settle timer in flight, so repeat announcements don't pile up timers. */
+    private final Map<Integer, Boolean> armed = new ConcurrentHashMap<>();
+
+    public StageAdoptScheduler(
+            TaskScheduler taskScheduler,
+            StageProgressionMonitor progressionMonitor,
+            RamseyConfig ramseyConfig) {
+        this.taskScheduler = taskScheduler;
+        this.progressionMonitor = progressionMonitor;
+        this.ramseyConfig = ramseyConfig;
+    }
+
+    /** A worker announced a new best for this stage. */
+    public void onNewBest(int stageId) {
+        long settleMs = ramseyConfig.getStage().getAdoptSettleMs();
+        if (settleMs <= 0) {
+            return; // timer disabled: the polling loop remains the only trigger
+        }
+        if (armed.putIfAbsent(stageId, Boolean.TRUE) != null) {
+            return; // already waiting on this stage
+        }
+        log.debug("Adopt settle timer armed for stage {} (+{}ms)", stageId, settleMs);
+        taskScheduler.schedule(() -> fire(stageId), Instant.now().plusMillis(settleMs));
+    }
+
+    private void fire(int stageId) {
+        try {
+            progressionMonitor.adoptAfterSettle(stageId);
+        } catch (Exception e) {
+            log.warn("Adopt-after-settle failed for stage {}: {}", stageId, e.toString());
+        } finally {
+            // Release so a later announcement can re-arm (needed near the floor, where the first
+            // improvement may be rejected and the next one arrives seconds later).
+            armed.remove(stageId);
+        }
+    }
+}

--- a/src/main/java/com/setminusx/ramsey/qm/controller/StageProgressionMonitor.java
+++ b/src/main/java/com/setminusx/ramsey/qm/controller/StageProgressionMonitor.java
@@ -318,6 +318,10 @@ public class StageProgressionMonitor {
         redisQueueService.deleteBestResult(currentStage.getStageId());
         redisQueueService.deleteTopResults(currentStage.getStageId());
 
+        // Tell the fleet immediately rather than letting each worker discover it on its next
+        // poll — at current stage rates that lag is a large slice of a stage's lifetime.
+        redisQueueService.publishStageAdvanced(createdStage.getCampaignId(), createdStage.getStageId());
+
         log.info("Stage progression complete! New stage {} is now active", createdStage.getStageId());
         return createdStage;
     }

--- a/src/main/java/com/setminusx/ramsey/qm/controller/StageProgressionMonitor.java
+++ b/src/main/java/com/setminusx/ramsey/qm/controller/StageProgressionMonitor.java
@@ -54,9 +54,25 @@ public class StageProgressionMonitor {
         // Per-stage state (Redis keys, exhaustion tracking) is stage-scoped, so
         // this is just a loop over the existing per-stage logic.
         for (Stage currentStage : middlewareClient.getActiveStages()) {
-            checkStageForProgression(currentStage);
+            synchronized (lockFor(currentStage.getCampaignId())) {
+                checkStageForProgression(currentStage);
+            }
         }
     }
+
+    /**
+     * Per-campaign lock serializing everything that ADVANCES a stage. The progression
+     * (30s) and perturbation (60s) loops run on separate scheduler threads (pool size 100),
+     * so without this they can both advance the same stage in the same instant and leave the
+     * campaign with TWO ACTIVE stages — two competing lineages that then progress forever in
+     * lockstep (observed on campaign 10: a kick and a normal advance 10ms apart). Locking per
+     * campaign (not globally) keeps unrelated campaigns progressing in parallel.
+     */
+    private Object lockFor(Integer campaignId) {
+        return campaignLocks.computeIfAbsent(campaignId, k -> new Object());
+    }
+
+    private final Map<Integer, Object> campaignLocks = new ConcurrentHashMap<>();
 
     private void checkStageForProgression(Stage currentStage) {
         Integer stageId = currentStage.getStageId();
@@ -232,7 +248,20 @@ public class StageProgressionMonitor {
      * (shared by normal progression and perturbation kicks): create stage, init
      * Redis counters, clear the old stage's keys.
      */
+    /**
+     * Advance a campaign: deactivate {@code currentStage} and create a new ACTIVE stage on
+     * {@code savedGraph}. Returns null (advancing nothing) if the stage is no longer ACTIVE —
+     * both scheduled loops iterate a snapshot of getActiveStages() taken before they acquire
+     * the campaign lock, so a stage can already have been advanced by the other loop by the
+     * time we get here. Advancing it again would create a SECOND active stage.
+     */
     private Stage switchToNewStage(Stage currentStage, Graph savedGraph, String details) {
+        if (!isStillActive(currentStage)) {
+            log.info("Stage {} is no longer ACTIVE (already advanced); skipping advance ({})",
+                    currentStage.getStageId(), details);
+            return null;
+        }
+
         // Mark current stage as INACTIVE
         log.info("Marking stage {} as INACTIVE", currentStage.getStageId());
         currentStage.setStatus(Stage.Status.INACTIVE);
@@ -300,7 +329,9 @@ public class StageProgressionMonitor {
         }
         for (Stage stage : middlewareClient.getActiveStages()) {
             try {
-                maybePerturbCampaign(stage);
+                synchronized (lockFor(stage.getCampaignId())) {
+                    maybePerturbCampaign(stage);
+                }
             } catch (Exception e) {
                 log.warn("Perturbation check failed for campaign {}: {}", stage.getCampaignId(), e.toString());
             }
@@ -374,6 +405,21 @@ public class StageProgressionMonitor {
         perturbAndAdvance(currentStage, incumbent, pairs, multiplier);
     }
 
+    /**
+     * True if the stage is still ACTIVE upstream. Fails OPEN on a middleware error: a transient
+     * fetch failure shouldn't stall legitimate progression, and the campaign lock already covers
+     * the common race.
+     */
+    private boolean isStillActive(Stage stage) {
+        try {
+            return middlewareClient.getActiveStages().stream()
+                    .anyMatch(s -> stage.getStageId().equals(s.getStageId()));
+        } catch (Exception e) {
+            log.warn("Could not verify stage {} still ACTIVE ({}); proceeding", stage.getStageId(), e.toString());
+            return true;
+        }
+    }
+
     private void resetKickTrackingIfImproved(Integer campaignId, Integer minStageId) {
         Integer lastKick = lastKickStageId.get(campaignId);
         if (lastKick != null && minStageId > lastKick) {
@@ -444,6 +490,13 @@ public class StageProgressionMonitor {
                     "PERTURBATION kick from graph " + incumbent.getGraphId()
                             + " (" + incumbent.getCliqueCount() + "), pairs=" + pairs
                             + ", escalation=x" + multiplier);
+            if (created == null) {
+                // The stage was advanced by the progression loop first; skip this kick and
+                // retry on a later tick (the campaign is still walled, so nothing is lost).
+                log.info("Perturbation: campaign {} stage advanced concurrently; skipping kick",
+                        currentStage.getCampaignId());
+                return;
+            }
             lastKickStageId.put(currentStage.getCampaignId(), created.getStageId());
             return;
         }

--- a/src/main/java/com/setminusx/ramsey/qm/controller/StageProgressionMonitor.java
+++ b/src/main/java/com/setminusx/ramsey/qm/controller/StageProgressionMonitor.java
@@ -346,7 +346,11 @@ public class StageProgressionMonitor {
             }
         }
 
-        int multiplier = Math.min(fruitlessKicks.getOrDefault(campaignId, 0) + 1, cfg.getEscalationCap());
+        // Geometric escalation: each consecutive fruitless kick doubles the strength
+        // (x1, x2, x4, x8, ...) up to the cap. streak is capped before the shift to avoid
+        // int overflow; the min with the cap bounds it regardless.
+        int streak = fruitlessKicks.getOrDefault(campaignId, 0);
+        int multiplier = Math.min(1 << Math.min(streak, 30), cfg.getEscalationCap());
         int pairs = cfg.getEdgePairs() * multiplier;
 
         Graph incumbent = middlewareClient.getGraphById(minPoint.getGraphId());

--- a/src/main/java/com/setminusx/ramsey/qm/controller/StageProgressionMonitor.java
+++ b/src/main/java/com/setminusx/ramsey/qm/controller/StageProgressionMonitor.java
@@ -364,38 +364,46 @@ public class StageProgressionMonitor {
         Integer campaignId = currentStage.getCampaignId();
 
         List<ProgressionPoint> history = middlewareClient.getProgression(campaignId);
-        if (history.size() < cfg.getWallStages()) {
-            return; // too young to be walled
+        if (history.size() < cfg.getBasinStaleStages()) {
+            return; // too young to have stalled
         }
 
-        // Campaign minimum (the incumbent) and the first stage that achieved it.
-        ProgressionPoint minPoint = history.stream()
-                .filter(p -> p.getCliqueCount() != null)
-                .min(java.util.Comparator.comparingLong(ProgressionPoint::getCliqueCount)
-                        .thenComparing(ProgressionPoint::getStageId))
-                .orElse(null);
+        // Campaign minimum (the incumbent) and the first stage that achieved it. This is what a
+        // kick restarts FROM, and what decides escalation — it is NOT the staleness clock.
+        ProgressionPoint minPoint = minPointFrom(history, Integer.MIN_VALUE);
         if (minPoint == null) {
             return;
         }
 
-        long stagesSinceMin = history.stream()
-                .filter(p -> p.getStageId() > minPoint.getStageId())
+        // Recover kick state after a restart before the gate, so the basin window below starts at
+        // the right stage and we don't re-kick early.
+        hydrateKickStateFromHistory(campaignId, history, minPoint);
+        Integer lastKick = lastKickStageId.get(campaignId);
+
+        // Staleness is measured inside the CURRENT BASIN — stages since this basin's own best
+        // stage — not as a fixed count since the kick. A descent that is still finding new minima
+        // therefore runs as long as it needs, and a basin that has flattened is kicked promptly.
+        // The fixed stages-since-kick wall did both badly: it cut three campaign-10 descents off
+        // while they were still in free fall (kicks 18/19/20 each bottomed out on their FINAL
+        // stage, floors 58k/158k/81k versus a 25,758 incumbent), while flat basins idled for
+        // thousands of stages after their floor had stopped moving.
+        //
+        // Before the first kick the basin IS the whole campaign, so this also subsumes the old
+        // "stages since the campaign min" wall.
+        int basinStart = lastKick == null ? Integer.MIN_VALUE : lastKick;
+        ProgressionPoint basinMin = minPointFrom(history, basinStart);
+        if (basinMin == null) {
+            return;
+        }
+        long stagesSinceBasinMin = history.stream()
+                .filter(p -> p.getStageId() > basinMin.getStageId())
                 .count();
-        if (stagesSinceMin < cfg.getWallStages()) {
+        if (stagesSinceBasinMin < cfg.getBasinStaleStages()) {
             resetKickTrackingIfImproved(campaignId, minPoint.getStageId());
-            return; // not walled
+            return; // basin is still improving
         }
 
-        // Recover kick state after a restart before the gate, so we don't re-kick early.
-        hydrateKickStateFromHistory(campaignId, history, minPoint);
-
-        // Don't re-kick until another full wall has elapsed since the last kick.
-        Integer lastKick = lastKickStageId.get(campaignId);
         if (lastKick != null) {
-            long stagesSinceKick = history.stream().filter(p -> p.getStageId() > lastKick).count();
-            if (stagesSinceKick < cfg.getWallStages()) {
-                return;
-            }
             // The previous kick produced no new min (min stage predates the kick) -> escalate.
             if (minPoint.getStageId() < lastKick) {
                 fruitlessKicks.merge(campaignId, 1, Integer::sum);
@@ -418,12 +426,28 @@ public class StageProgressionMonitor {
             return;
         }
 
-        log.info("PERTURBATION: campaign {} walled ({} stages past min {} @ stage {}); kicking incumbent "
-                        + "graph {} with {} edge pairs (escalation x{})",
-                campaignId, stagesSinceMin, minPoint.getCliqueCount(), minPoint.getStageId(),
+        log.info("PERTURBATION: campaign {} basin stale ({} stages past basin floor {} @ stage {}; "
+                        + "incumbent {} @ stage {}); kicking incumbent graph {} with {} edge pairs "
+                        + "(escalation x{})",
+                campaignId, stagesSinceBasinMin, basinMin.getCliqueCount(), basinMin.getStageId(),
+                minPoint.getCliqueCount(), minPoint.getStageId(),
                 incumbent.getGraphId(), pairs, multiplier);
 
         perturbAndAdvance(currentStage, incumbent, pairs, multiplier);
+    }
+
+    /**
+     * Lowest-count point at or after {@code fromStageId}, earliest stage breaking ties.
+     * With {@link Integer#MIN_VALUE} this is the campaign incumbent; with the last kick's stage
+     * it is the current basin's floor. The kick stage itself is always a spike (a perturbed graph
+     * counts far worse than the incumbent it came from), so including it never skews the min.
+     */
+    private static ProgressionPoint minPointFrom(List<ProgressionPoint> history, int fromStageId) {
+        return history.stream()
+                .filter(p -> p.getCliqueCount() != null && p.getStageId() >= fromStageId)
+                .min(java.util.Comparator.comparingLong(ProgressionPoint::getCliqueCount)
+                        .thenComparing(ProgressionPoint::getStageId))
+                .orElse(null);
     }
 
     /**

--- a/src/main/java/com/setminusx/ramsey/qm/controller/StageProgressionMonitor.java
+++ b/src/main/java/com/setminusx/ramsey/qm/controller/StageProgressionMonitor.java
@@ -61,6 +61,27 @@ public class StageProgressionMonitor {
     }
 
     /**
+     * Settle timer fired for a stage: adopt the best result available now. Triggered by
+     * {@link StageAdoptScheduler} a deliberate settle window after a worker announced the stage's
+     * first new best, which is both earlier and more precisely timed than the polling loop (whose
+     * settle time is random 0..pollInterval and whose interval also floors the stage duration).
+     *
+     * <p>Runs the SAME per-stage logic as the loop, under the same per-campaign lock, so this is
+     * purely a better-timed trigger rather than a second code path. No-ops if the stage is no
+     * longer active (the loop or another timer already advanced it).
+     */
+    public void adoptAfterSettle(int stageId) {
+        for (Stage stage : middlewareClient.getActiveStages()) {
+            if (stage.getStageId() != null && stage.getStageId() == stageId) {
+                synchronized (lockFor(stage.getCampaignId())) {
+                    checkStageForProgression(stage);
+                }
+                return;
+            }
+        }
+    }
+
+    /**
      * Per-campaign lock serializing everything that ADVANCES a stage. The progression
      * (30s) and perturbation (60s) loops run on separate scheduler threads (pool size 100),
      * so without this they can both advance the same stage in the same instant and leave the

--- a/src/main/java/com/setminusx/ramsey/qm/controller/StageProgressionMonitor.java
+++ b/src/main/java/com/setminusx/ramsey/qm/controller/StageProgressionMonitor.java
@@ -277,12 +277,15 @@ public class StageProgressionMonitor {
     ////////////////////////////////////////////////////////////////////////////////
 
     // Per-campaign: the stage id of the last kick, and how many consecutive kicks
-    // have happened without a new campaign minimum (drives escalation). In-memory:
-    // after a QM restart the worst case is one early re-kick of a walled campaign,
-    // which is harmless (kicks always start from the campaign-minimum incumbent).
+    // have happened without a new campaign minimum (drives escalation). These live in
+    // memory but are REHYDRATED from persisted history on first use after a restart
+    // (hydrateKickStateFromHistory), so a QM restart resumes the wall/escalation instead
+    // of firing an early kick and resetting the escalation ladder.
     private final Map<Integer, Integer> lastKickStageId = new ConcurrentHashMap<>();
     private final Map<Integer, Integer> fruitlessKicks = new ConcurrentHashMap<>();
     private final java.util.Random perturbationRandom = new java.util.Random();
+    // Kick stages are recognized by this details prefix (set when a kick creates its stage).
+    static final String KICK_DETAILS_PREFIX = "PERTURBATION";
 
     /**
      * ILS kick: when a campaign has gone {@code wallStages} stages with no new
@@ -331,6 +334,9 @@ public class StageProgressionMonitor {
             return; // not walled
         }
 
+        // Recover kick state after a restart before the gate, so we don't re-kick early.
+        hydrateKickStateFromHistory(campaignId, history, minPoint);
+
         // Don't re-kick until another full wall has elapsed since the last kick.
         Integer lastKick = lastKickStageId.get(campaignId);
         if (lastKick != null) {
@@ -373,6 +379,40 @@ public class StageProgressionMonitor {
         if (lastKick != null && minStageId > lastKick) {
             fruitlessKicks.remove(campaignId); // the kick paid off
         }
+    }
+
+    /**
+     * Restore in-memory kick state from the persisted progression after a QM restart, so a
+     * restart doesn't skip the re-kick gate (firing an early kick) or reset the escalation
+     * ladder. No-op once the campaign has in-memory state, or if it has never been kicked.
+     * Kick stages are identified authoritatively by their {@code PERTURBATION} details
+     * marker (a clique-count heuristic is unreliable: big kicks' descents drift wildly and
+     * cross any threshold many times). Escalation streak = kicks after the current min,
+     * minus the last one (whose own fruitfulness is only decided at the next kick), matching
+     * the live counter.
+     */
+    void hydrateKickStateFromHistory(Integer campaignId, List<ProgressionPoint> history, ProgressionPoint minPoint) {
+        if (lastKickStageId.containsKey(campaignId)) {
+            return; // in-memory state is authoritative once present
+        }
+        List<Integer> kickStages = history.stream()
+                .filter(p -> p.getDetails() != null && p.getDetails().startsWith(KICK_DETAILS_PREFIX))
+                .map(ProgressionPoint::getStageId)
+                .sorted()
+                .toList();
+        if (kickStages.isEmpty()) {
+            return; // never kicked -> leave state empty (first-kick behavior)
+        }
+        int lastKick = kickStages.get(kickStages.size() - 1);
+        lastKickStageId.put(campaignId, lastKick);
+        long kicksAfterMin = kickStages.stream().filter(s -> s > minPoint.getStageId()).count();
+        int streak = (int) Math.max(0, kicksAfterMin - 1);
+        if (streak > 0) {
+            fruitlessKicks.put(campaignId, streak);
+        }
+        log.info("PERTURBATION: rehydrated kick state for campaign {} from history "
+                + "({} kicks, lastKick stage {}, fruitless streak {})",
+                campaignId, kickStages.size(), lastKick, streak);
     }
 
     private void perturbAndAdvance(Stage currentStage, Graph incumbent, int pairs, int multiplier) {

--- a/src/main/java/com/setminusx/ramsey/qm/model/ProgressionPoint.java
+++ b/src/main/java/com/setminusx/ramsey/qm/model/ProgressionPoint.java
@@ -10,4 +10,5 @@ public class ProgressionPoint {
     private Long cliqueCount;
     private String createdDate;
     private String status;
+    private String details; // e.g. "PERTURBATION kick from graph ..." — used to recover kick stages on restart
 }

--- a/src/main/java/com/setminusx/ramsey/qm/service/RedisQueueService.java
+++ b/src/main/java/com/setminusx/ramsey/qm/service/RedisQueueService.java
@@ -136,6 +136,31 @@ public class RedisQueueService {
     /**
      * Clear counter-based keys for a stage (on stage progression).
      */
+    /**
+     * Channel workers watch to learn a stage has advanced.
+     *
+     * They otherwise find out by polling the fleet endpoint once per work cycle, which at current
+     * stage rates leaves them a large fraction of a stage behind: work finished against a
+     * superseded stage is written to keys this class has already cleared, and workers drift onto
+     * different graphs so they cannot pool the per-edge fill. One channel carries every campaign
+     * and workers filter, so a fleet being repointed needs no resubscribe.
+     */
+    public static final String STAGE_ADVANCED_CHANNEL = "stage_advanced";
+
+    /**
+     * Announce that a campaign's active stage changed. Fire-and-forget: Redis pub/sub has no
+     * delivery guarantee and workers keep polling the fleet endpoint regardless, so a dropped
+     * message costs latency, never correctness.
+     */
+    public void publishStageAdvanced(Integer campaignId, Integer stageId) {
+        try {
+            redisTemplate.convertAndSend(STAGE_ADVANCED_CHANNEL,
+                    String.format("{\"campaignId\":%d,\"stageId\":%d}", campaignId, stageId));
+        } catch (Exception e) {
+            log.warn("Could not announce stage {} for campaign {}: {}", stageId, campaignId, e.toString());
+        }
+    }
+
     public void clearStageCounter(Integer stageId) {
         String indexKey = STAGE_WORK_INDEX_PREFIX + stageId;
         String configKey = STAGE_CONFIG_PREFIX + stageId;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,7 @@ ramsey:
     frequency-in-millis: ${STAGE_PROGRESSION_FREQUENCY_MS:30000}
   stage:
     top-results-count: ${TOP_RESULTS_COUNT:10}
+    adopt-settle-ms: ${STAGE_ADOPT_SETTLE_MS:0}
     exhaustion-delay-ms: ${EXHAUSTION_DELAY_MS:60000}
     cycle-prevention-graph-lookback-count: ${CYCLE_PREVENTION_GRAPH_LOOKBACK_COUNT:50}
     immediately-progress-on-improvement: ${IMMEDIATELY_PROGRESS_STAGE_ON_IMPROVEMENT:true}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,7 +22,7 @@ ramsey:
     immediately-progress-on-improvement: ${IMMEDIATELY_PROGRESS_STAGE_ON_IMPROVEMENT:true}
   perturbation:
     enabled: ${PERTURBATION_ENABLED:false}
-    wall-stages: ${PERTURBATION_WALL_STAGES:500}
+    basin-stale-stages: ${PERTURBATION_BASIN_STALE_STAGES:100}
     edge-pairs: ${PERTURBATION_EDGE_PAIRS:30}
     escalation-cap: ${PERTURBATION_ESCALATION_CAP:4}
     max-novelty-retries: ${PERTURBATION_MAX_NOVELTY_RETRIES:5}

--- a/src/test/java/com/setminusx/ramsey/qm/controller/PerturbationTest.java
+++ b/src/test/java/com/setminusx/ramsey/qm/controller/PerturbationTest.java
@@ -164,6 +164,67 @@ class PerturbationTest {
         verify(mw, never()).createStage(any());
     }
 
+    /** A progression point tagged as a perturbation kick (how kicks are recovered on restart). */
+    private ProgressionPoint kickPoint(int stageId, long clique) {
+        ProgressionPoint p = point(stageId, clique);
+        p.setDetails("PERTURBATION kick from graph 100 (1000), pairs=60, escalation=x1");
+        return p;
+    }
+
+    @Test
+    void restart_recentKick_hydratesFromHistory_doesNotReKickEarly() {
+        MiddlewareClient mw = mock(MiddlewareClient.class);
+        RedisQueueService redis = mock(RedisQueueService.class);
+        when(mw.getActiveStages()).thenReturn(List.of(activeStage(700, 3)));
+
+        // Fresh QM (no in-memory kick state). History: min 1000 @ stage 100, then walled,
+        // with a KICK (details-tagged) at stage 650 — only 50 stages ago, i.e. < wallStages
+        // 500. The old code (lastKick == null) would skip the gate and re-kick; hydration
+        // must recover lastKick=650 and hold.
+        List<ProgressionPoint> h = new ArrayList<>();
+        for (int i = 1; i < 100; i++) h.add(point(i, 1100 + i));
+        h.add(point(100, 1000)); // min
+        for (int i = 101; i <= 700; i++) h.add(i == 650 ? kickPoint(i, 1050) : point(i, 1050));
+        when(mw.getProgression(3)).thenReturn(h);
+
+        new StageProgressionMonitor(mw, redis, config(true, 500)).checkForPerturbation();
+
+        verify(mw, never()).createGraph(any()); // no early re-kick
+    }
+
+    @Test
+    void restart_oldKick_hydratesFromHistory_stillKicksWhenWallElapsed() {
+        MiddlewareClient mw = mock(MiddlewareClient.class);
+        RedisQueueService redis = mock(RedisQueueService.class);
+        Stage current = activeStage(700, 3);
+        when(mw.getActiveStages()).thenReturn(List.of(current));
+
+        // Same shape but the kick is at stage 120 — 580 stages ago (>= 500), so the wall
+        // since the recovered kick HAS elapsed and a (legitimate) kick should fire.
+        List<ProgressionPoint> h = new ArrayList<>();
+        for (int i = 1; i < 100; i++) h.add(point(i, 1100 + i));
+        h.add(point(100, 1000)); // min
+        for (int i = 101; i <= 700; i++) h.add(i == 120 ? kickPoint(i, 1050) : point(i, 1050));
+        when(mw.getProgression(3)).thenReturn(h);
+        Graph incumbent = new Graph();
+        incumbent.setGraphId(100);
+        incumbent.setEdgeData("1".repeat(10));
+        incumbent.setVertexCount(5);
+        incumbent.setSubgraphSize(5);
+        when(mw.getGraphById(100)).thenReturn(incumbent);
+        when(redis.isGraphAlreadyProcessed(anyString())).thenReturn(false);
+        Graph saved = new Graph();
+        saved.setGraphId(9000);
+        when(mw.createGraph(any())).thenReturn(saved);
+        Stage created = new Stage();
+        created.setStageId(701);
+        when(mw.createStage(any())).thenReturn(created);
+
+        new StageProgressionMonitor(mw, redis, config(true, 500)).checkForPerturbation();
+
+        verify(mw).createGraph(any()); // wall elapsed since recovered kick -> kicks
+    }
+
     private static int count(String s, char c) {
         return (int) s.chars().filter(x -> x == c).count();
     }

--- a/src/test/java/com/setminusx/ramsey/qm/controller/PerturbationTest.java
+++ b/src/test/java/com/setminusx/ramsey/qm/controller/PerturbationTest.java
@@ -225,6 +225,38 @@ class PerturbationTest {
         verify(mw).createGraph(any()); // wall elapsed since recovered kick -> kicks
     }
 
+    /**
+     * Regression: the progression and perturbation loops iterate a snapshot of getActiveStages()
+     * and run on separate scheduler threads. If the stage was already advanced by the other loop,
+     * kicking it again would create a SECOND active stage (two competing lineages, as seen live on
+     * campaign 10). The kick must be skipped when the stage is no longer ACTIVE.
+     */
+    @Test
+    void staleStage_alreadyAdvanced_doesNotCreateSecondActiveStage() {
+        MiddlewareClient mw = mock(MiddlewareClient.class);
+        RedisQueueService redis = mock(RedisQueueService.class);
+        Stage stale = activeStage(1000, 3);
+        // The loop's snapshot still contains stage 1000, but upstream it is gone (advanced to 1001).
+        when(mw.getActiveStages())
+                .thenReturn(List.of(stale))          // snapshot the loop iterates
+                .thenReturn(List.of(activeStage(1001, 3))); // re-read inside switchToNewStage
+        when(mw.getProgression(3)).thenReturn(walledHistory(400, 1000, 600));
+        Graph incumbent = new Graph();
+        incumbent.setGraphId(400);
+        incumbent.setEdgeData("1".repeat(10));
+        incumbent.setVertexCount(5);
+        incumbent.setSubgraphSize(5);
+        when(mw.getGraphById(400)).thenReturn(incumbent);
+        when(redis.isGraphAlreadyProcessed(anyString())).thenReturn(false);
+        Graph saved = new Graph();
+        saved.setGraphId(9000);
+        when(mw.createGraph(any())).thenReturn(saved);
+
+        new StageProgressionMonitor(mw, redis, config(true, 500)).checkForPerturbation();
+
+        verify(mw, never()).createStage(any()); // no second ACTIVE stage
+    }
+
     private static int count(String s, char c) {
         return (int) s.chars().filter(x -> x == c).count();
     }

--- a/src/test/java/com/setminusx/ramsey/qm/controller/PerturbationTest.java
+++ b/src/test/java/com/setminusx/ramsey/qm/controller/PerturbationTest.java
@@ -45,11 +45,11 @@ class PerturbationTest {
 
     // ---------- wall detection / kick behavior ----------
 
-    private RamseyConfig config(boolean enabled, int wallStages) {
+    private RamseyConfig config(boolean enabled, int basinStaleStages) {
         RamseyConfig config = mock(RamseyConfig.class);
         RamseyConfig.Perturbation p = new RamseyConfig.Perturbation();
         p.setEnabled(enabled);
-        p.setWallStages(wallStages);
+        p.setBasinStaleStages(basinStaleStages);
         p.setEdgePairs(2);
         lenient().when(config.getPerturbation()).thenReturn(p);
         RamseyConfig.Stage stageCfg = new RamseyConfig.Stage();
@@ -223,6 +223,97 @@ class PerturbationTest {
         new StageProgressionMonitor(mw, redis, config(true, 500)).checkForPerturbation();
 
         verify(mw).createGraph(any()); // wall elapsed since recovered kick -> kicks
+    }
+
+    /**
+     * Campaign incumbent at stage 100, a details-tagged kick at {@code kickStage}, then one basin
+     * point per stage with counts from {@code basinCount} (indexed 1..basinLen). The kick point
+     * itself is a big spike, as a real perturbed graph always is.
+     */
+    private List<ProgressionPoint> kickedHistory(
+            long campaignMin, int kickStage, java.util.function.IntToLongFunction basinCount, int basinLen) {
+        List<ProgressionPoint> h = new ArrayList<>();
+        for (int i = 1; i < 100; i++) h.add(point(i, campaignMin + 1000 + i));
+        h.add(point(100, campaignMin)); // campaign incumbent
+        for (int i = 101; i < kickStage; i++) h.add(point(i, campaignMin + 50));
+        h.add(kickPoint(kickStage, 5_000_000));
+        for (int i = 1; i <= basinLen; i++) h.add(point(kickStage + i, basinCount.applyAsLong(i)));
+        return h;
+    }
+
+    private void stubKickTargets(MiddlewareClient mw, RedisQueueService redis, int incumbentGraphId) {
+        Graph incumbent = new Graph();
+        incumbent.setGraphId(incumbentGraphId);
+        incumbent.setEdgeData("1".repeat(10));
+        incumbent.setVertexCount(5);
+        incumbent.setSubgraphSize(5);
+        incumbent.setCliqueCount(1);
+        lenient().when(mw.getGraphById(incumbentGraphId)).thenReturn(incumbent);
+        lenient().when(redis.isGraphAlreadyProcessed(anyString())).thenReturn(false);
+        Graph saved = new Graph();
+        saved.setGraphId(9000);
+        lenient().when(mw.createGraph(any())).thenReturn(saved);
+        Stage created = new Stage();
+        created.setStageId(99999);
+        lenient().when(mw.createStage(any())).thenReturn(created);
+    }
+
+    /**
+     * The staleness clock runs from the BASIN FLOOR, not from the kick, so a descent that is
+     * still finding new minima is never interrupted — however long it runs. Under the old fixed
+     * stages-since-kick wall this basin (1,800 stages past its kick, still in free fall) would
+     * have been cut off; that is exactly how campaign 10's kicks 18/19/20 died, each bottoming
+     * out on its FINAL stage at 58k/158k/81k against a 25,758 incumbent.
+     */
+    @Test
+    void basinStillDescending_isNeverKicked_howeverLongTheDescentRuns() {
+        MiddlewareClient mw = mock(MiddlewareClient.class);
+        RedisQueueService redis = mock(RedisQueueService.class);
+        when(mw.getActiveStages()).thenReturn(List.of(activeStage(2000, 3)));
+        when(mw.getProgression(3)).thenReturn(kickedHistory(1000, 200, i -> 50_000 - i * 10L, 1800));
+        stubKickTargets(mw, redis, 100);
+
+        new StageProgressionMonitor(mw, redis, config(true, 500)).checkForPerturbation();
+
+        verify(mw, never()).createGraph(any());
+        verify(mw, never()).createStage(any());
+    }
+
+    /**
+     * Mirror image: once the floor stops moving the basin is kicked after exactly
+     * basinStaleStages, without sitting out the remainder of a long fixed wall.
+     */
+    @Test
+    void basinFlattened_kicksOnceTheFloorStopsMoving() {
+        MiddlewareClient mw = mock(MiddlewareClient.class);
+        RedisQueueService redis = mock(RedisQueueService.class);
+        when(mw.getActiveStages()).thenReturn(List.of(activeStage(2000, 3)));
+        // Descends for 50 stages to a floor of 49,500 at stage 250, then 500 flat stages.
+        when(mw.getProgression(3)).thenReturn(
+                kickedHistory(1000, 200, i -> i <= 50 ? 50_000 - i * 10L : 49_500L, 550));
+        stubKickTargets(mw, redis, 100);
+
+        new StageProgressionMonitor(mw, redis, config(true, 500)).checkForPerturbation();
+
+        verify(mw).getGraphById(100); // kicks the campaign incumbent, not the basin floor graph
+        verify(mw).createGraph(any());
+        verify(mw).createStage(any());
+    }
+
+    /** One improvement inside the stale window restarts the clock. */
+    @Test
+    void basinImprovingIntermittently_holdsTheKickOff() {
+        MiddlewareClient mw = mock(MiddlewareClient.class);
+        RedisQueueService redis = mock(RedisQueueService.class);
+        when(mw.getActiveStages()).thenReturn(List.of(activeStage(2000, 3)));
+        // Flat except for a single new floor 400 stages in — only 150 stages of staleness since.
+        when(mw.getProgression(3)).thenReturn(
+                kickedHistory(1000, 200, i -> i == 400 ? 49_000L : 49_500L, 550));
+        stubKickTargets(mw, redis, 100);
+
+        new StageProgressionMonitor(mw, redis, config(true, 500)).checkForPerturbation();
+
+        verify(mw, never()).createGraph(any());
     }
 
     /**

--- a/src/test/java/com/setminusx/ramsey/qm/controller/StageAdoptSchedulerTest.java
+++ b/src/test/java/com/setminusx/ramsey/qm/controller/StageAdoptSchedulerTest.java
@@ -1,0 +1,103 @@
+package com.setminusx.ramsey.qm.controller;
+
+import com.setminusx.ramsey.qm.config.RamseyConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.scheduling.TaskScheduler;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class StageAdoptSchedulerTest {
+
+    private RamseyConfig config(long settleMs) {
+        RamseyConfig config = mock(RamseyConfig.class);
+        RamseyConfig.Stage stage = new RamseyConfig.Stage();
+        stage.setAdoptSettleMs(settleMs);
+        lenient().when(config.getStage()).thenReturn(stage);
+        return config;
+    }
+
+    @Test
+    void settleDisabled_schedulesNothing() {
+        TaskScheduler scheduler = mock(TaskScheduler.class);
+        StageProgressionMonitor monitor = mock(StageProgressionMonitor.class);
+
+        new StageAdoptScheduler(scheduler, monitor, config(0)).onNewBest(42);
+
+        verify(scheduler, never()).schedule(any(Runnable.class), any(Instant.class));
+    }
+
+    @Test
+    void firstAnnouncementArmsOnce_repeatsAreIgnored() {
+        TaskScheduler scheduler = mock(TaskScheduler.class);
+        StageProgressionMonitor monitor = mock(StageProgressionMonitor.class);
+        StageAdoptScheduler adopt = new StageAdoptScheduler(scheduler, monitor, config(500));
+
+        // Workers publish on EVERY record-break — many per stage; only the first may arm a timer.
+        adopt.onNewBest(42);
+        adopt.onNewBest(42);
+        adopt.onNewBest(42);
+
+        verify(scheduler, times(1)).schedule(any(Runnable.class), any(Instant.class));
+    }
+
+    @Test
+    void distinctStagesEachArm() {
+        TaskScheduler scheduler = mock(TaskScheduler.class);
+        StageProgressionMonitor monitor = mock(StageProgressionMonitor.class);
+        StageAdoptScheduler adopt = new StageAdoptScheduler(scheduler, monitor, config(500));
+
+        adopt.onNewBest(42);
+        adopt.onNewBest(43);
+
+        verify(scheduler, times(2)).schedule(any(Runnable.class), any(Instant.class));
+    }
+
+    @Test
+    void firingAdoptsAndReleasesTheArmSoALaterAnnouncementCanReArm() {
+        List<Runnable> scheduled = new ArrayList<>();
+        TaskScheduler scheduler = mock(TaskScheduler.class);
+        when(scheduler.schedule(any(Runnable.class), any(Instant.class)))
+                .thenAnswer(inv -> {
+                    scheduled.add(inv.getArgument(0));
+                    return null;
+                });
+        StageProgressionMonitor monitor = mock(StageProgressionMonitor.class);
+        StageAdoptScheduler adopt = new StageAdoptScheduler(scheduler, monitor, config(500));
+
+        adopt.onNewBest(42);
+        assertEquals(1, scheduled.size());
+        scheduled.get(0).run(); // timer fires
+        verify(monitor).adoptAfterSettle(42);
+
+        // Near the floor a fired timer may not have advanced the stage (candidate already
+        // visited); a later announcement must be able to arm again.
+        adopt.onNewBest(42);
+        assertEquals(2, scheduled.size());
+    }
+
+    @Test
+    void adoptFailureStillReleasesTheArm() {
+        List<Runnable> scheduled = new ArrayList<>();
+        TaskScheduler scheduler = mock(TaskScheduler.class);
+        when(scheduler.schedule(any(Runnable.class), any(Instant.class)))
+                .thenAnswer(inv -> {
+                    scheduled.add(inv.getArgument(0));
+                    return null;
+                });
+        StageProgressionMonitor monitor = mock(StageProgressionMonitor.class);
+        doThrow(new RuntimeException("middleware down")).when(monitor).adoptAfterSettle(42);
+        StageAdoptScheduler adopt = new StageAdoptScheduler(scheduler, monitor, config(500));
+
+        adopt.onNewBest(42);
+        assertDoesNotThrow(() -> scheduled.get(0).run());
+
+        adopt.onNewBest(42); // not wedged
+        assertEquals(2, scheduled.size());
+    }
+}


### PR DESCRIPTION
## Kick on basin staleness, not a fixed stages-since-kick wall

`PERTURBATION_WALL_STAGES` gated re-kicks on a fixed count of stages since the last kick, so a basin still descending got cut off mid-free-fall. On campaign 10 that killed kicks 11/14/15/16/18/19/20 — each one's minimum is its FINAL stage, with floors of 58k/158k/81k against a 25,758 incumbent.

The clock now runs from the basin's own floor: stages since this basin last beat itself. A descent still finding new minima is never interrupted however long it takes, and a basin that has flattened is kicked promptly. This also subsumes the old campaign-min wall — before the first kick the basin IS the whole campaign, so one gate replaces two.

Replaying all 22 campaign-10 basins: the seven that were truncated improve on every stage (max gap between new minima = 1), so they now run on. Near the floor the gap between successive new minima reaches 249 stages, so the window is a real depth/breadth knob — `PERTURBATION_BASIN_STALE_STAGES`.

Verified live: fired at exactly 101 stages past the basin floor, kicking the incumbent rather than the drifted base.

## Announce stage advances on Redis pub/sub

Workers learned a stage had advanced by polling the fleet endpoint once per work cycle. At current stage rates that left them a large fraction of a stage behind: work finished against a superseded stage lands in keys the QM has already cleared, and the fleet drifts across graphs so it cannot pool the per-edge hoist fill.

One channel carries every campaign and subscribers filter, so repointing a fleet needs no resubscribe. Fire-and-forget — workers keep polling regardless, so a dropped message costs latency, never correctness.

Also included: geometric escalation, restart-durable kick state, the two-active-stages race fix, and the pub/sub-armed settle timer (previously unmerged on this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7XjzEBwfnWeVv9KRSrWWr