### PR TITLE
Size the work space for SEQUENTIAL_WITH_SINGLES too

### DIFF
--- a/src/main/java/com/setminusx/ramsey/qm/controller/StageProgressionMonitor.java
+++ b/src/main/java/com/setminusx/ramsey/qm/controller/StageProgressionMonitor.java
@@ -587,7 +587,11 @@ public class StageProgressionMonitor {
      */
     static long computeTotalWorkUnits(long redCount, long blueCount, String strategy) {
         long pairs = redCount * blueCount;
-        if ("DUAL_EDGE_CARDINALITY_WITH_SINGLES".equals(strategy)) {
+        // Both ..._WITH_SINGLES strategies enumerate the same space — every edge as a single flip,
+        // then every (red, blue) pair. They differ only in the ORDER within each block, so the
+        // total is identical and the worker's cross-check passes either way.
+        if ("DUAL_EDGE_CARDINALITY_WITH_SINGLES".equals(strategy)
+                || "SEQUENTIAL_WITH_SINGLES".equals(strategy)) {
             return redCount + blueCount + pairs;
         }
         return pairs;

--- a/src/test/java/com/setminusx/ramsey/qm/controller/StageProgressionMonitorTest.java
+++ b/src/test/java/com/setminusx/ramsey/qm/controller/StageProgressionMonitorTest.java
@@ -180,4 +180,22 @@ class StageProgressionMonitorTest {
         b.setGraphBitstring("0101"); // SA-style result -> simple hash path
         return b;
     }
+
+    /**
+     * Both ..._WITH_SINGLES strategies enumerate the same space and differ only in ordering, so
+     * they must produce the same total. The worker refuses a stage whose total disagrees with the
+     * enumerator it builds, so a mismatch here would stall the fleet outright.
+     */
+    @Test
+    void sequential_and_cardinality_strategies_agree_on_the_total() {
+        long red = 19811, blue = 19810;
+        long expected = red + blue + red * blue;
+        assertEquals(expected,
+                StageProgressionMonitor.computeTotalWorkUnits(red, blue, "SEQUENTIAL_WITH_SINGLES"));
+        assertEquals(expected,
+                StageProgressionMonitor.computeTotalWorkUnits(red, blue, "DUAL_EDGE_CARDINALITY_WITH_SINGLES"));
+        // A strategy without a singles block is pairs only.
+        assertEquals(red * blue,
+                StageProgressionMonitor.computeTotalWorkUnits(red, blue, "DUAL_EDGE_CARDINALITY"));
+    }
 }


### PR DESCRIPTION
Same work space as `DUAL_EDGE_CARDINALITY_WITH_SINGLES` — every edge as a single flip, then every (red, blue) pair — but in plain edge order, with no cardinality scoring and no sort.

**Measured on a live graph: 13.47 ms → 89 µs to build, 151× cheaper**, for an identical 392,495,531-unit space.

The ordering existed to sweep likely-improving moves first. That mattered when a sweep took ~233 s and a stage only ever saw part of its space. A sweep is now ~6 s, stages routinely reach most or all of it, and the QM adopts the best of the top-50 rather than the first found — so the order no longer changes which result is adopted. The closest measured analogue of the heuristic (participation rank) backtested at **zero signal** against 4,637 real winners.

Plain edge order should also suit the hoisted path better: consecutive units walk consecutive blue edges, whose per-edge table entries are adjacent in memory.

⚠️ **The strategy name crosses three services and each holds it differently** — the QM matches on the string to size the work space, the worker deserializes it into its own enum, and the middleware's entity enum decides whether a stage POST is accepted at all. Adding it to only some of them rejects every stage creation with a 400. Tests now pin this on both sides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7XjzEBwfnWeVv9KRSrWWr