### PR TITLE
Publish a stage only once its Redis config exists

### DIFF
--- a/src/main/java/com/setminusx/ramsey/qm/controller/StageProgressionMonitor.java
+++ b/src/main/java/com/setminusx/ramsey/qm/controller/StageProgressionMonitor.java
@@ -30,6 +30,11 @@ import java.util.stream.Collectors;
 @Component
 public class StageProgressionMonitor {
 
+    /** Attempts to flip a prepared stage to ACTIVE before giving up. See {@link #activateStage}. */
+    private static final int ACTIVATION_ATTEMPTS = 3;
+    /** Pause between activation attempts. Short: the fleet is idle until this succeeds. */
+    private static final long ACTIVATION_RETRY_MILLIS = 50L;
+
     private final MiddlewareClient middlewareClient;
     private final RedisQueueService redisQueueService;
     private final RamseyConfig ramseyConfig;
@@ -288,9 +293,20 @@ public class StageProgressionMonitor {
         currentStage.setStatus(Stage.Status.INACTIVE);
         middlewareClient.updateStage(currentStage);
 
-        // Create new active stage with default enumeration strategy
+        // Create the new stage INACTIVE, seed its Redis config, and only then activate it.
+        //
+        // Workers discover work in two steps: they read the campaign's ACTIVE stage from the
+        // middleware, then read stage_config:{stageId} from Redis. Creating the stage ACTIVE
+        // before seeding that config published a stage that could not yet be worked. Every worker
+        // polling inside the gap found no config, cleared its stage cache and slept 25ms —
+        // measured at 19-73ms of gap per stage, ~13% of a stage's lifetime at the current
+        // sub-second cadence, and ~13.5% of each worker's wall clock spent in those retries.
+        //
+        // Creating it INACTIVE closes the gap: the stage is invisible until it is workable. Note
+        // this narrows rather than widens the two-competing-lineages hazard described above —
+        // the window now holds ZERO active stages for this campaign rather than one.
         Stage newStage = new Stage();
-        newStage.setStatus(Stage.Status.ACTIVE);
+        newStage.setStatus(Stage.Status.INACTIVE);
         newStage.setBaseGraphId(savedGraph.getGraphId());
         newStage.setCampaignId(currentStage.getCampaignId());
         newStage.setDetails(details);
@@ -303,13 +319,16 @@ public class StageProgressionMonitor {
         }
 
         Stage createdStage = middlewareClient.createStage(newStage);
-        log.info("Created new stage {} with base graph {} ({})",
+        log.info("Created new stage {} (inactive) with base graph {} ({})",
                 createdStage.getStageId(), savedGraph.getGraphId(), details);
 
         // Initialize counter-based mode for new stage (before clearing old stage)
         if (createdStage.getWorkEnumerationStrategy() != null) {
             initializeRedisForStage(createdStage, savedGraph);
         }
+
+        // Config is in place — publish the stage to the fleet.
+        activateStage(createdStage);
 
         // Clear Redis queue and counter keys for old stage
         log.info("Clearing Redis keys for old stage {}", currentStage.getStageId());
@@ -324,6 +343,43 @@ public class StageProgressionMonitor {
 
         log.info("Stage progression complete! New stage {} is now active", createdStage.getStageId());
         return createdStage;
+    }
+
+    /**
+     * Flip a fully-prepared stage to ACTIVE, retrying briefly on a transient middleware error.
+     *
+     * <p>Between creating the stage and this call the campaign has no ACTIVE stage, and nothing
+     * else will reactivate it: {@link #ensureActiveStageInitialized()} repairs a missing Redis
+     * config but returns early when there is no active stage to repair. A momentary blip must
+     * therefore not be able to strand a campaign, so retry before giving up — and if it is still
+     * failing, say exactly what a human has to do about it.
+     */
+    private void activateStage(Stage stage) {
+        stage.setStatus(Stage.Status.ACTIVE);
+        for (int attempt = 1; attempt <= ACTIVATION_ATTEMPTS; attempt++) {
+            try {
+                middlewareClient.updateStage(stage);
+                return;
+            } catch (RuntimeException e) {
+                log.warn("Activating stage {} failed (attempt {}/{}): {}",
+                        stage.getStageId(), attempt, ACTIVATION_ATTEMPTS, e.toString());
+                if (attempt < ACTIVATION_ATTEMPTS) {
+                    sleepQuietly(ACTIVATION_RETRY_MILLIS);
+                }
+            }
+        }
+        log.error("Could not activate stage {} after {} attempts. Campaign {} now has NO active "
+                + "stage and its workers will idle until this is repaired "
+                + "(set stage {} to ACTIVE).",
+                stage.getStageId(), ACTIVATION_ATTEMPTS, stage.getCampaignId(), stage.getStageId());
+    }
+
+    private void sleepQuietly(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
     }
 
     ////////////////////////////////////////////////////////////////////////////////

--- a/src/test/java/com/setminusx/ramsey/qm/controller/StageProgressionMonitorTest.java
+++ b/src/test/java/com/setminusx/ramsey/qm/controller/StageProgressionMonitorTest.java
@@ -7,6 +7,8 @@ import com.setminusx.ramsey.qm.model.Graph;
 import com.setminusx.ramsey.qm.model.Stage;
 import com.setminusx.ramsey.qm.service.RedisQueueService;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 
 import java.util.List;
 
@@ -14,7 +16,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -197,5 +203,54 @@ class StageProgressionMonitorTest {
         // A strategy without a singles block is pairs only.
         assertEquals(red * blue,
                 StageProgressionMonitor.computeTotalWorkUnits(red, blue, "DUAL_EDGE_CARDINALITY"));
+    }
+
+    /**
+     * A stage must not become discoverable before it is workable.
+     *
+     * <p>Workers find work in two steps: read the campaign's ACTIVE stage from the middleware,
+     * then read {@code stage_config:{stageId}} from Redis. Creating the stage ACTIVE before
+     * seeding that config advertised a stage nobody could work, and every worker polling inside
+     * the gap cleared its cache and slept — measured at ~13% of each worker's wall clock. So the
+     * stage is created INACTIVE and only flipped to ACTIVE once the config exists.
+     */
+    @Test
+    void newStageBecomesActiveOnlyAfterItsRedisConfigIsSeeded() {
+        MiddlewareClient mw = mock(MiddlewareClient.class);
+        RedisQueueService redis = mock(RedisQueueService.class);
+        RamseyConfig config = mock(RamseyConfig.class);
+
+        RamseyConfig.Stage stageCfg = new RamseyConfig.Stage();
+        when(config.getStage()).thenReturn(stageCfg);
+
+        when(mw.getActiveStages()).thenReturn(List.of(activeStage()));
+        when(mw.getGraphById(7)).thenReturn(baseGraph(100));
+        when(redis.getTopResults(42, 1)).thenReturn(List.of(improvement(90)));
+        when(redis.isGraphAlreadyProcessed(anyString())).thenReturn(false);
+
+        Graph saved = baseGraph(90);
+        saved.setGraphId(8);
+        saved.setEdgeData("0101"); // 2 red / 2 blue, enough for the work-unit total
+        when(mw.createGraph(any())).thenReturn(saved);
+
+        Stage created = new Stage();
+        created.setStageId(43);
+        created.setCampaignId(10);
+        created.setBaseGraphId(8);
+        created.setWorkEnumerationStrategy("SEQUENTIAL_WITH_SINGLES"); // so Redis seeding runs
+        when(mw.createStage(any())).thenReturn(created);
+
+        new StageProgressionMonitor(mw, redis, config).checkForProgression();
+
+        // It is created INACTIVE — never advertised before its config exists.
+        ArgumentCaptor<Stage> createArg = ArgumentCaptor.forClass(Stage.class);
+        verify(mw).createStage(createArg.capture());
+        assertEquals(Stage.Status.INACTIVE, createArg.getValue().getStatus());
+
+        // ...and the seeding strictly precedes the activation.
+        InOrder order = inOrder(redis, mw);
+        order.verify(redis).initializeStageCounter(eq(43), any(), any(), anyLong(), anyString());
+        order.verify(mw).updateStage(argThat(
+                s -> s.getStageId() == 43 && s.getStatus() == Stage.Status.ACTIVE));
     }
 }


### PR DESCRIPTION
## Problem

Workers find work in two steps: read the campaign's ACTIVE stage from the middleware, then read `stage_config:{stageId}` from Redis. The new stage was created **ACTIVE** and its config seeded immediately afterwards — so between those two calls the fleet was advertised a stage nobody could work. Every worker polling inside that gap cleared its stage cache and slept 25ms.

Measured on one worker over 60s, before:

- gap of **19–73ms per stage** — ~13% of a stage's lifetime at the current sub-second cadence
- **217 config-missing retries = 13.5% of the worker's wall clock**

## Change

Create the stage `INACTIVE`, seed the config, then activate it. The stage is invisible until it is workable.

This **narrows** rather than widens the two-competing-lineages hazard documented above `switchToNewStage`: the window now holds *zero* active stages for the campaign rather than one.

`activateStage()` retries because nothing else would recover a stage left INACTIVE — `ensureActiveStageInitialized()` repairs a missing Redis config but returns early when there is no active stage to repair — and if it still fails it logs exactly what a human must do. Note the same no-active-stage exposure already existed between deactivating the old stage and creating the new one; this widens that window by roughly one HTTP call.

## Result (same worker, same conditions)

| | before | after |
|---|---|---|
| config races | 217 (13.5% of wall) | 103 (4.2%) |
| stages/sec | 3.13 | 3.60 |
| worker CPU | 73% | 63% |

CPU falling while stage rate rises is the point: less spinning, more progress.

Of the residual races only **2** were on the current stage. The other **83** were a separate stale-pointer race — the middleware's cached active-stage answer naming an already-retired stage — fixed in `ramsey-mw` and `ramsey-worker-rust`.

## Test

`newStageBecomesActiveOnlyAfterItsRedisConfigIsSeeded` asserts the stage is created INACTIVE and that Redis seeding strictly precedes activation (Mockito `InOrder`). Verified it actually bites — reverting just the status line fails it with `expected: <INACTIVE> but was: <ACTIVE>`.

37 tests green. Deployed and validated on the live fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7XjzEBwfnWeVv9KRSrWWr